### PR TITLE
Add securityContext to deployment

### DIFF
--- a/kubernetes/razeedash-api/resource.yaml
+++ b/kubernetes/razeedash-api/resource.yaml
@@ -28,6 +28,9 @@ items:
             app: razeedash-api
           name: razeedash-api
         spec:
+          securityContext:
+            fsGroup: 999
+            runAsUser: 999
           initContainers:
           - env:
             - name: MONGO_URL


### PR DESCRIPTION
Make sure we can run Razee Dashboard API on a Kubernetes system
where we don't allow containers to execute as root user.