### PR TITLE
Sync deletes old

### DIFF
--- a/app/routes/v2/clusters.js
+++ b/app/routes/v2/clusters.js
@@ -68,11 +68,12 @@ const pushToS3 = async (req, key, dataStr) => {
 
 var deleteOrgClusterResourceSelfLinks = async(req, orgId, clusterId, selfLinks)=>{
   const Resources = req.db.collection('resources');
+  selfLinks = _.filter(selfLinks); // in such a case that a null is passed to us. if you do $in:[null], it returns all items missing the attr, which is not what we want
   if(selfLinks.length < 1){
     return;
   }
   if(!orgId || !clusterId){
-    throw `missing orgId or clusterId: ${JSON.stringify({orgId, clusterId})}`;
+    throw `missing orgId or clusterId: ${JSON.stringify({ orgId, clusterId })}`;
   }
   var search = {
     org_id: orgId,
@@ -82,6 +83,36 @@ var deleteOrgClusterResourceSelfLinks = async(req, orgId, clusterId, selfLinks)=
     }
   };
   await Resources.deleteMany(search);
+};
+
+const syncClusterResources = async(req, res, next)=>{
+  const orgId = req.org._id;
+  const clusterId = req.params.cluster_id;
+  const Resources = req.db.collection('resources');
+  const Stats = req.db.collection('resourceStats');
+
+  var result = await Resources.updateMany(
+      { org_id: orgId, cluster_id: clusterId, updated: { $lt: new moment().subtract(1, 'hour').toDate() }, deleted: { $ne: true} },
+      { $set: { deleted: true }, $currentDate: { updated: true } },
+  );
+  req.log.debug({ org_id: orgId, cluster_id: clusterId }, `${result.modifiedCount} resources marked as deleted:true`);
+
+  // deletes items >1day old
+  var objsToDelete = await Resources.find(
+      { org_id: orgId, cluster_id: clusterId, deleted: true, updated: { $lt: new moment().subtract(1, 'day').toDate() } },
+      { projection: { _id:1, selfLink: 1, updated: 1, } }
+  ).toArray();
+
+  if(objsToDelete.length > 0){
+    // if we have items that were marked as deleted and havent updated in >=1day, then deletes them
+    var selfLinksToDelete = _.map(objsToDelete, 'selfLink');
+    req.log.info({ org_id: orgId, cluster_id: clusterId, resourceObjs: objsToDelete }, `deleting ${selfLinksToDelete.length} resource objs`);
+    await deleteOrgClusterResourceSelfLinks(req, orgId, clusterId, selfLinksToDelete);
+
+    Stats.updateOne({ org_id: orgId }, { $inc: { deploymentCount: -1 * objsToDelete.length } });
+  }
+
+  res.status(200).send('Thanks');
 };
 
 const updateClusterResources = async (req, res, next) => {
@@ -104,29 +135,6 @@ const updateClusterResources = async (req, res, next) => {
     for (let resource of resources) {
       const type = resource['type'] || 'other';
       switch (type.toUpperCase()) {
-        case 'SYNC': {
-          // marks >1hr old items as deleted:true
-          var result = await Resources.updateMany(
-            { org_id: req.org._id, cluster_id: req.params.cluster_id, updated: { $lt: new moment().subtract(1, 'hour').toDate() }, deleted: { $ne: true} },
-            { $set: { deleted: true }, $currentDate: { updated: true } },
-          );
-          req.log.debug({ org_id: req.org._id, cluster_id: req.params.cluster_id }, `${result.modifiedCount} resources marked as deleted:true`);
-
-          // deletes items >1day old
-          var objsToDelete = await Resources.find(
-            { org_id: req.org._id, cluster_id: req.params.cluster_id, deleted: true, updated: { $lt: new moment().subtract(1, 'day').toDate() } },
-            { projection: { _id:1, selfLink: 1, updated: 1, } }
-          ).toArray();
-
-          if(objsToDelete.length > 0){
-            // if we have items that were marked as deleted and havent updated in >=1day, then deletes them
-            var selfLinksToDelete = _.map(objsToDelete, 'selfLink');
-            req.log.info({ org_id: req.org._id, cluster_id: req.params.cluster_id, resourceObjs: objsToDelete }, `deleting ${selfLinksToDelete.length} resource objs`);
-            await deleteOrgClusterResourceSelfLinks(req, req.org._id, req.params.cluster_id, selfLinksToDelete);
-          }
-
-          break;
-        }
         case 'POLLED':
         case 'MODIFIED':
         case 'ADDED': {
@@ -292,6 +300,9 @@ router.post('/:cluster_id', asyncHandler(addUpdateCluster));
 
 // /api/v2/clusters/:cluster_id/resources
 router.post('/:cluster_id/resources', asyncHandler(getCluster), asyncHandler(updateClusterResources));
+
+// /api/v2/clusters/:cluster_id/resources/sync
+router.post('/:cluster_id/resources/sync', asyncHandler(getCluster), asyncHandler(syncClusterResources));
 
 // /api/v2/clusters/:cluster_id/messages
 router.post('/:cluster_id/messages', asyncHandler(getCluster), asyncHandler(addClusterMessages));

--- a/app/routes/v2/clusters.js
+++ b/app/routes/v2/clusters.js
@@ -85,22 +85,22 @@ var deleteOrgClusterResourceSelfLinks = async(req, orgId, clusterId, selfLinks)=
   await Resources.deleteMany(search);
 };
 
-const syncClusterResources = async(req, res, next)=>{
+const syncClusterResources = async(req, res)=>{
   const orgId = req.org._id;
   const clusterId = req.params.cluster_id;
   const Resources = req.db.collection('resources');
   const Stats = req.db.collection('resourceStats');
 
   var result = await Resources.updateMany(
-      { org_id: orgId, cluster_id: clusterId, updated: { $lt: new moment().subtract(1, 'hour').toDate() }, deleted: { $ne: true} },
-      { $set: { deleted: true }, $currentDate: { updated: true } },
+    { org_id: orgId, cluster_id: clusterId, updated: { $lt: new moment().subtract(1, 'hour').toDate() }, deleted: { $ne: true} },
+    { $set: { deleted: true }, $currentDate: { updated: true } },
   );
   req.log.debug({ org_id: orgId, cluster_id: clusterId }, `${result.modifiedCount} resources marked as deleted:true`);
 
   // deletes items >1day old
   var objsToDelete = await Resources.find(
-      { org_id: orgId, cluster_id: clusterId, deleted: true, updated: { $lt: new moment().subtract(1, 'day').toDate() } },
-      { projection: { _id:1, selfLink: 1, updated: 1, } }
+    { org_id: orgId, cluster_id: clusterId, deleted: true, updated: { $lt: new moment().subtract(1, 'day').toDate() } },
+    { projection: { _id:1, selfLink: 1, updated: 1, } }
   ).toArray();
 
   if(objsToDelete.length > 0){

--- a/app/routes/v2/clusters.js
+++ b/app/routes/v2/clusters.js
@@ -100,7 +100,7 @@ const syncClusterResources = async(req, res)=>{
   // deletes items >1day old
   var objsToDelete = await Resources.find(
     { org_id: orgId, cluster_id: clusterId, deleted: true, updated: { $lt: new moment().subtract(1, 'day').toDate() } },
-    { projection: { _id:1, selfLink: 1, updated: 1, } }
+    { projection: { selfLink: 1, updated: 1, } }
   ).toArray();
 
   if(objsToDelete.length > 0){

--- a/app/routes/v2/clusters.tests.js
+++ b/app/routes/v2/clusters.tests.js
@@ -19,6 +19,7 @@ const mongodb = require('mongo-mock');
 var httpMocks = require('node-mocks-http');
 const objectHash = require('object-hash');
 const log = require('../../log').log;
+var moment = require('moment');
 
 const rewire = require('rewire');
 let v2 = rewire('./clusters');
@@ -655,7 +656,8 @@ describe('clusters', () => {
           deleted: false,
           hash: hash_a,
           data: JSON.stringify(data_a),
-          $currentData: { created: true, updated: true }
+          $currentData: { created: true, },
+          updated: new moment().toDate()
         }
       );
       const data_b = { 'kind': 'Deployment', 'apiVersion': 'apps/v1', 'metadata': { 'name': 'watch-keeper', 'namespace': 'razee', 'selfLink': '/apis/apps/v1/namespaces/razee/deployments/watch-keeper2', 'uid': '672ff712-7c9f-11e9-b757-ce243beadde5', 'resourceVersion': '131921', 'generation': 1, 'creationTimestamp': '2019-05-22T14:39:28Z', 'labels': { 'razee/watch-resource': 'detail' }, 'annotations': { 'deployment.kubernetes.io/revision': '1', 'razee.io/commit-sha': 'ec8ca9edcb1c24f137773a8fb681a1d327ebe770', 'razee.io/git-repo': 'https://github.com/razee-io/Watch-keeper.git', 'version': 'ec8ca9edcb1c24f137773a8fb681a1d327ebe770' } }, 'spec': { 'replicas': 1, 'selector': { 'matchLabels': { 'app': 'watch-keeper' } }, 'template': { 'metadata': { 'name': 'watch-keeper', 'creationTimestamp': null, 'labels': { 'app': 'watch-keeper' } }, 'spec': { 'containers': [{ 'name': 'watch-keeper', 'image': 'quay.io/razee/watch-keeper:0.0.3', 'env': [{ 'name': 'START_DELAY_MAX', 'valueFrom': { 'configMapKeyRef': { 'name': 'watch-keeper-config', 'key': 'START_DELAY_MAX', 'optional': true } } }, { 'name': 'NAMESPACE', 'valueFrom': { 'fieldRef': { 'apiVersion': 'v1', 'fieldPath': 'metadata.namespace' } } }, { 'name': 'RAZEEDASH_URL', 'valueFrom': { 'configMapKeyRef': { 'name': 'watch-keeper-config', 'key': 'RAZEEDASH_URL' } } }, { 'name': 'RAZEEDASH_ORG_KEY', 'valueFrom': { 'secretKeyRef': { 'name': 'watch-keeper-secret', 'key': 'RAZEEDASH_ORG_KEY' } } }, { 'name': 'NODE_ENV', 'value': 'REDACTED' }], 'resources': { 'limits': { 'cpu': '400m', 'memory': '500Mi' }, 'requests': { 'cpu': '50m', 'memory': '100Mi' } }, 'livenessProbe': { 'exec': { 'command': ['sh/liveness.sh'] }, 'initialDelaySeconds': 600, 'timeoutSeconds': 30, 'periodSeconds': 300, 'successThreshold': 1, 'failureThreshold': 1 }, 'terminationMessagePath': '/dev/termination-log', 'terminationMessagePolicy': 'File', 'imagePullPolicy': 'Always' }], 'restartPolicy': 'Always', 'terminationGracePeriodSeconds': 30, 'dnsPolicy': 'ClusterFirst', 'serviceAccountName': 'watch-keeper-sa', 'serviceAccount': 'watch-keeper-sa', 'securityContext': {}, 'schedulerName': 'default-scheduler' } }, 'strategy': { 'type': 'RollingUpdate', 'rollingUpdate': { 'maxUnavailable': '25%', 'maxSurge': '25%' } }, 'revisionHistoryLimit': 0, 'progressDeadlineSeconds': 600 }, 'status': { 'observedGeneration': 1, 'replicas': 1, 'updatedReplicas': 1, 'readyReplicas': 1, 'availableReplicas': 1, 'conditions': [{ 'type': 'Available', 'status': 'True', 'lastUpdateTime': '2019-05-22T14:39:32Z', 'lastTransitionTime': '2019-05-22T14:39:32Z', 'reason': 'MinimumReplicasAvailable', 'message': 'Deployment has minimum availability.' }, { 'type': 'Progressing', 'status': 'True', 'lastUpdateTime': '2019-05-22T14:39:32Z', 'lastTransitionTime': '2019-05-22T14:39:28Z', 'reason': 'NewReplicaSetAvailable', 'message': 'ReplicaSet watch-keeper-6678dd4f6f has successfully progressed.' }] } };
@@ -671,13 +673,14 @@ describe('clusters', () => {
           deleted: false,
           hash: hash_b,
           data: JSON.stringify(data_b),
-          $currentData: { created: true, updated: true }
+          $currentData: { created: true, },
+          updated: new moment().subtract(2, 'days').toDate()
         }
       );
-      let updateClusterResources = v2.__get__('updateClusterResources');
+      let syncClusterResources = v2.__get__('syncClusterResources');
       var request = httpMocks.createRequest({
         method: 'POST',
-        url: `${cluster_id}/resources`, params: {
+        url: `${cluster_id}/resources/sync`, params: {
           cluster_id: cluster_id
         },
         org: {
@@ -697,7 +700,7 @@ describe('clusters', () => {
         assert.equal(err.message, null);
       };
 
-      await updateClusterResources(request, response, next);
+      await syncClusterResources(request, response, next);
       const resource_a = await Resources.findOne(key_a);
       assert.equal(resource_a.deleted, false);
       const resource_b = await Resources.findOne(key_b);


### PR DESCRIPTION
updated sync call to be its own endpoint and not require the list of selfLinks.
Marks `deleted:true` for all resources not updated in past hour. also actually deletes items >=1day old.
Lets wait until monday to merge