### PR TITLE
Update rendered YAML to use new name 'deploy.razee.io'

### DIFF
--- a/app/routes/install/cluster.yaml
+++ b/app/routes/install/cluster.yaml
@@ -24,7 +24,7 @@ metadata:
 data:
   RAZEEDASH_ORG_KEY: "{{{RAZEEDASH_ORG_KEY}}}"
 ---
-apiVersion: "kapitan.razee.io/v1alpha1"
+apiVersion: "deploy.razee.io/v1alpha1"
 kind: RemoteResource
 metadata:
   name: watch-keeper-rr


### PR DESCRIPTION
Generate a resource YAML file with the new renamed apiVersion
otherwise the resource will not apply cleanly on a cluster that
only has the new CRDs (Custom Resource Definitions) installed.