### PR TITLE
Use user `node` inside Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,7 @@ ENV PATH="$PATH:/usr/src/"
 WORKDIR /usr/src/
 COPY --from=buildImg /usr/src /usr/src
 
+USER node
+
 EXPOSE 3333
 CMD ["npm", "start"]

--- a/kubernetes/razeedash-api/resource.yaml
+++ b/kubernetes/razeedash-api/resource.yaml
@@ -28,9 +28,6 @@ items:
             app: razeedash-api
           name: razeedash-api
         spec:
-          securityContext:
-            fsGroup: 999
-            runAsUser: 999
           initContainers:
           - env:
             - name: MONGO_URL


### PR DESCRIPTION
To avoid the problems caused by inclusion of the securityContext
in pull request #84 lets instead switch the user inside the docker
container to the node user already created inside the upstream
image. This way we run as UID != 0 and we don't hard code a UID
and GID that causes problems when running on Openshift clusters
where the 999 values where too low.

```
Warning   FailedCreate   replicaset/razeedash-dfc7b5fd5
Error creating: pods "razeedash-dfc7b5fd5-" is forbidden: unable to validate against
any security context constraint: [fsGroup: Invalid value: []int64{999}:
999 is not an allowed group spec.containers[0].securityContext.securityContext.runAsUser:
Invalid value: 999: must be in the ranges: [1000200000, 1000209999]]
```