### PR TITLE
sends obj on sub change events instead of array of urls

### DIFF
--- a/app/subs/subscriptions.js
+++ b/app/subs/subscriptions.js
@@ -53,7 +53,7 @@ module.exports = async(orgKey, socket)=>{
     // otherwise maybe we need to update
     var curSubs = await Subscriptions.aggregate([
       { $match: { 'org_id': orgId } },
-      { $project: { tags: 1, version: 1, channel: 1, isSubSet: { $setIsSubset: ['$tags', tags ] } } },
+      { $project: { name: 1, uuid: 1, tags: 1, version: 1, channel: 1, isSubSet: { $setIsSubset: ['$tags', tags ] } } },
       { $match: { 'isSubSet': true } }
     ]).toArray();
     curSubs = _.sortBy(curSubs, '_id');
@@ -76,7 +76,15 @@ module.exports = async(orgKey, socket)=>{
 
     log.info(`sending urls to ${socket.id}`, { urls });
 
-    socket.emit('subscriptions', urls);
+    // exposes the name and uuid fields to the user
+    var publicSubs = _.map(curSubs, (sub)=>{
+      return _.pick(sub, ['name', 'uuid']);
+    });
+
+    socket.emit('subscriptions', {
+      subscriptions: publicSubs,
+      urls,
+    });
 
     prevSubs = curSubs;
 

--- a/app/subs/subscriptions.tests.js
+++ b/app/subs/subscriptions.tests.js
@@ -129,15 +129,15 @@ describe('subs', () => {
       _.set(socket, 'handshake.query.tags', 'aaaa,bbbb');
 
       var result = await (new Promise(async(resolve)=>{
-        sinon.replace(socket, 'emit', (type, urls)=>{
-          resolve([ type, urls ]);
+        sinon.replace(socket, 'emit', (type, data)=>{
+          resolve([ type, data ]);
         });
         var result = await subscriptions(orgKey, socket);
         assert(result, true);
       }));
 
       assert(result[0] == 'subscriptions');
-      assert.deepEqual(result[1], fakeUrls);
+      assert.deepEqual(result[1].urls, fakeUrls);
 
       result = await lastOnMsg({ orgId });
       assert(result == false);


### PR DESCRIPTION
# MERGE https://github.com/razee-io/ClusterSubscription/pull/17 FIRST

Changes format of sub change event object.
Old way: array of urls
```js
[ 'api/v1/channels/bbbbb/1c9a1e5b-742c-40a2-bdd8-3773a9711f18' ]
```
New way: obj with urls and subs list
```js
{
  subscriptions: [
    { name: 'aaaaa', uuid: 'a07803dc-5899-4d74-951d-963780ef27a2' }
  ],
  urls: [ 'api/v1/channels/bbbbb/1c9a1e5b-742c-40a2-bdd8-3773a9711f18' ]
}
```

# MERGE https://github.com/razee-io/ClusterSubscription/pull/17 FIRST
