### PR TITLE
Update: allow tags as a query parameter to /razeedeploy-job

### DIFF
--- a/app/routes/install/index.js
+++ b/app/routes/install/index.js
@@ -31,6 +31,9 @@ router.get('/razeedeploy-job', asyncHandler(async (req, res, next) => {
   let args_array = Array.isArray(args) ? args : [args];
   args_array.push(`--razeedash-url=${req.protocol}://${req.get('host')}/api/v2`);
   args_array.push(`--razeedash-org-key=${req.query.orgKey}`);
+  if(req.query.tags) {
+    args_array.push(`--razeedash-tags=${req.query.tags}`);
+  }
   args_array = JSON.stringify(args_array);
 
   try {


### PR DESCRIPTION
This will add tags to `--razeedash-tags=` if supplied in the url.  For example:

https://razeeapi/api/install/razeedeploy-job?orgKey=orgApiKey-aaaa-1111-bbbb&tags=one,two
