### PR TITLE
Chan sub UUID

### DIFF
--- a/app/apollo/resolvers/channel.js
+++ b/app/apollo/resolvers/channel.js
@@ -15,7 +15,7 @@
  */
 
 const _ = require('lodash');
-const UUID = require('uuid').v4;
+const { v4: UUID } = require('uuid');
 const crypto = require('crypto');
 
 const { ACTIONS, TYPES } = require('../models/const');

--- a/app/apollo/resolvers/subscription.js
+++ b/app/apollo/resolvers/subscription.js
@@ -15,7 +15,8 @@
  */
 
 const _ = require('lodash');
-const uuid = require('uuid').v4;
+const UUID = require('uuid').v4;
+const { pub } = require('../../utils/pubsub');
 
 const { ACTIONS, TYPES } = require('../models/const');
 const { whoIs, validAuth } = require ('./common');
@@ -45,7 +46,7 @@ const resourceResolvers = {
 
       return subscriptions;
     },
-    subscription: async(parent, { org_id, _id }, context) => {
+    subscription: async(parent, { org_id, uuid }, context) => {
       const { models, me, req_id, logger } = context;
       const queryName = 'subscription';
       logger.debug({req_id, user: whoIs(me), org_id }, `${queryName} enter`);
@@ -54,7 +55,7 @@ const resourceResolvers = {
       try{
         var subscriptions = await resourceResolvers.Query.subscriptions(parent, { org_id }, { models, me, req_id, logger });
         var subscription = subscriptions.find((sub)=>{
-          return (sub._id == _id);
+          return (sub.uuid == uuid);
         });
         return subscription;
       }catch(err){
@@ -71,7 +72,7 @@ const resourceResolvers = {
       await validAuth(me, org_id, ACTIONS.MANAGE, TYPES.SUBSCRIPTION, queryName, context);
 
       try{
-        const _id = uuid();
+        const uuid = UUID();
 
         // loads the channel
         var channel = await models.Channel.findOne({ org_id, uuid: channel_uuid });
@@ -88,11 +89,19 @@ const resourceResolvers = {
         }
 
         await models.Subscription.create({
-          _id, org_id, name, tags, uuid: uuid(), owner: me._id,
+          _id: UUID(),
+          uuid, org_id, name, tags, owner: me._id,
           channel: channel.name, channel_uuid, version: version.name, version_uuid
         });
+
+        var msg = {
+          orgId: org_id,
+          groupName: name,
+        };
+        pub('addSubscription', msg);
+
         return {
-          _id,
+          uuid,
         };
       }
       catch(err){
@@ -100,16 +109,16 @@ const resourceResolvers = {
         throw err;
       }
     },
-    editSubscription: async (parent, { org_id, _id, name, tags, channel_uuid, version_uuid }, context)=>{
+    editSubscription: async (parent, { org_id, uuid, name, tags, channel_uuid, version_uuid }, context)=>{
       const { models, me, req_id, logger } = context;
       const queryName = 'editSubscription';
       logger.debug({req_id, user: whoIs(me), org_id }, `${queryName} enter`);
       await validAuth(me, org_id, ACTIONS.MANAGE, TYPES.SUBSCRIPTION, queryName, context);
 
       try{
-        var subscription = await models.Subscription.findOne({ org_id, _id });
+        var subscription = await models.Subscription.findOne({ org_id, uuid });
         if(!subscription){
-          throw `subscription { _id: "${_id}", org_id:${org_id} } not found`;
+          throw `subscription { uuid: "${uuid}", org_id:${org_id} } not found`;
         }
 
         // loads the channel
@@ -130,10 +139,17 @@ const resourceResolvers = {
           name, tags,
           channel: channel.name, channel_uuid, version: version.name, version_uuid,
         };
-        await models.Subscription.updateOne({ _id, org_id, }, { $set: sets });
+        await models.Subscription.updateOne({ uuid, org_id, }, { $set: sets });
+
+        var msg = {
+          orgId: org_id,
+          groupName: name,
+          subscription,
+        };
+        pub('updateSubscription', msg);
 
         return {
-          _id,
+          uuid,
           success: true,
         };
       }
@@ -142,7 +158,7 @@ const resourceResolvers = {
         throw err;
       }
     },
-    removeSubscription: async (parent, { org_id, _id }, context)=>{
+    removeSubscription: async (parent, { org_id, uuid }, context)=>{
       const { models, me, req_id, logger } = context;
       const queryName = 'removeSubscription';
       logger.debug({req_id, user: whoIs(me), org_id }, `${queryName} enter`);
@@ -150,21 +166,28 @@ const resourceResolvers = {
 
       var success = false;
       try{
-        var subscription = await models.Subscription.findOne({ org_id, _id });
+        var subscription = await models.Subscription.findOne({ org_id, uuid });
         if(!subscription){
-          throw `subscription id "${_id}" not found`;
+          throw `subscription uuid "${uuid}" not found`;
         }
         await subscription.deleteOne();
+
+        var msg = {
+          orgId: org_id,
+          groupName: subscription.name,
+        };
+        pub('removeSubscription', msg);
+
         success = true;
       }catch(err){
         logger.error(err);
         throw err;
       }
       return {
-        _id, success,
+        uuid, success,
       };
     },
-  }
+  },
 };
 
 module.exports = resourceResolvers;

--- a/app/apollo/resolvers/subscription.js
+++ b/app/apollo/resolvers/subscription.js
@@ -15,7 +15,7 @@
  */
 
 const _ = require('lodash');
-const UUID = require('uuid').v4;
+const { v4: UUID } = require('uuid');
 const { pub } = require('../../utils/pubsub');
 
 const { ACTIONS, TYPES } = require('../models/const');

--- a/app/apollo/schema/channel.js
+++ b/app/apollo/schema/channel.js
@@ -25,18 +25,17 @@ const channelSchema = gql`
     location: String!  
   }
   type Channel {
-    _id: ID!
+    uuid: String!
     org_id: String!
     name: String!
-    uuid: String!
     created: Date!
     versions: [ChannelVersion]
   }
   type AddChannelReply {
-    _id: String!
+    uuid: String!
   }
   type EditChannelReply {
-    _id: String!
+    uuid: String!
     name: String!
     success: Boolean
   }
@@ -45,7 +44,7 @@ const channelSchema = gql`
     success: Boolean!
   }
   type RemoveChannelReply {
-    _id: String!
+    uuid: String!
     success: Boolean
   }
   
@@ -64,17 +63,17 @@ const channelSchema = gql`
      """
      Edits a channel
      """
-     editChannel(org_id: String!, _id: String!, name: String!): EditChannelReply!
+     editChannel(org_id: String!, uuid: String!, name: String!): EditChannelReply!
      
      """
      Adds a yaml version to this channel
      """
-     addChannelVersion(org_id: String!, channel_id: String!, name: String!, type: String!, content: String!, description: String): AddChannelVersionReply!
+     addChannelVersion(org_id: String!, channel_uuid: String!, name: String!, type: String!, content: String!, description: String): AddChannelVersionReply!
      
      """
      Removes a channel
      """
-     removeChannel(org_id: String!, _id: String!): RemoveChannelReply!
+     removeChannel(org_id: String!, uuid: String!): RemoveChannelReply!
   }
 `;
 

--- a/app/apollo/schema/subscription.js
+++ b/app/apollo/schema/subscription.js
@@ -22,10 +22,9 @@ const subscriptionSchema = gql`
     name: String!
   }
   type ChannelSubscription {
-    _id: String!
+    uuid: String!
     org_id: String!
     name: String!
-    uuid: String!
     tags: [String!]!
     channel_uuid: String!
     channel: String!
@@ -36,15 +35,15 @@ const subscriptionSchema = gql`
     updated: Date!
   }
   type RemoveChannelSubscriptionReply {
-    _id: String!
+    uuid: String!
     success: Boolean
   }
   type EditChannelSubscriptionReply {
-    _id: String!
+    uuid: String!
     success: Boolean
   }
   type AddChannelSubscriptionReply {
-    _id: String!
+    uuid: String!
   }
   
   extend type Query {
@@ -55,7 +54,7 @@ const subscriptionSchema = gql`
      """
      Get a single subscriptions
      """
-     subscription(org_id: String!, _id: String!): ChannelSubscription
+     subscription(org_id: String!, uuid: String!): ChannelSubscription
   }
   extend type Mutation {
      """
@@ -66,12 +65,12 @@ const subscriptionSchema = gql`
      """
      Edits a subscription
      """
-     editSubscription(org_id: String!, _id: String!, name: String!, tags: [String!]!, channel_uuid: String!, version_uuid: String!): EditChannelSubscriptionReply!
+     editSubscription(org_id: String!, uuid: String!, name: String!, tags: [String!]!, channel_uuid: String!, version_uuid: String!): EditChannelSubscriptionReply!
      
      """
      Removes a subscription
      """
-     removeSubscription(org_id: String!, _id: String!): RemoveChannelSubscriptionReply
+     removeSubscription(org_id: String!, uuid: String!): RemoveChannelSubscriptionReply
   }
 `;
 


### PR DESCRIPTION
Makes the code use the `uuid` field as the identifier for chans/subs rather than _id. Also adds some pubsub publish calls, although websockets in razeeapi look broken right now, so I cant test them.

`mks-ui/pull/57` aligns with these changes, so ideally we'd get them both pushed out at the same time.