### PR TITLE
add 2 cluster delete apis

### DIFF
--- a/app/apollo/resolvers/cluster.js
+++ b/app/apollo/resolvers/cluster.js
@@ -200,6 +200,8 @@ const clusterResolvers = {
         const deletedCluster = await models.Cluster.findOneAndDelete({org_id,
           cluster_id});
 
+        //TODO: soft delete the resources for now. We need to have a background process to
+        // clean up S3 contents based on deleted flag. 
         const deletedResources = await models.Resource.updateMany({ org_id, cluster_id }, 
           {$set: { deleted: true }}, { upsert: false });
 
@@ -228,6 +230,8 @@ const clusterResolvers = {
       try {
         const deletedClusters = await models.Cluster.deleteMany({ org_id });
 
+        //TODO: soft delete the resources for now. We need to have a background process to
+        // clean up S3 contents based on deleted flag. 
         const deletedResources = await models.Resource.updateMany({ org_id }, 
           {$set: { deleted: true }}, { upsert: false });
 

--- a/app/apollo/schema/cluster.js
+++ b/app/apollo/schema/cluster.js
@@ -44,6 +44,16 @@ const clusterSchema = gql`
     count: Int
   }
 
+  type DeleteClusterByClusterIDResponse {
+    deletedClusterCount: Int,
+    deletedResourceCount: Int
+  }
+
+  type DeleteClustersResponse {
+    deletedClusterCount: Int,
+    deletedResourceCount: Int
+  }
+
   extend type Query {
     """
     Return a cluster based on **org_id** and **cluster_id**.
@@ -91,6 +101,19 @@ const clusterSchema = gql`
     """
     clusterCountByKubeVersion(org_id: String!): [ClusterCountByKubeVersion]!
   }
+
+  extend type Mutation {
+    """
+    Delete a cluster and all resources under the cluster
+    """
+    deleteClusterByClusterID(org_id: String!, cluster_id: String!): DeleteClusterByClusterIDResponse!
+
+    """
+    Delete all clusters under an organization and all resources under the deleted clusters
+    """
+    deleteClusters(org_id: String!): DeleteClustersResponse!
+  }
+
 `;
 
 module.exports = clusterSchema;

--- a/app/apollo/schema/cluster.js
+++ b/app/apollo/schema/cluster.js
@@ -44,11 +44,6 @@ const clusterSchema = gql`
     count: Int
   }
 
-  type DeleteClusterByClusterIDResponse {
-    deletedClusterCount: Int,
-    deletedResourceCount: Int
-  }
-
   type DeleteClustersResponse {
     deletedClusterCount: Int,
     deletedResourceCount: Int
@@ -106,7 +101,7 @@ const clusterSchema = gql`
     """
     Delete a cluster and all resources under the cluster
     """
-    deleteClusterByClusterID(org_id: String!, cluster_id: String!): DeleteClusterByClusterIDResponse!
+    deleteClusterByClusterID(org_id: String!, cluster_id: String!): DeleteClustersResponse!
 
     """
     Delete all clusters under an organization and all resources under the deleted clusters

--- a/app/apollo/test/clusterApi.js
+++ b/app/apollo/test/clusterApi.js
@@ -243,6 +243,48 @@ const clusterFunc = grahqlUrl => {
       },
     );
 
+  const deleteClusterByClusterID = async (token, variables) =>
+    axios.post(
+      grahqlUrl,
+      {
+        query: `
+          mutation($org_id: String! $cluster_id: String!) {
+            deleteClusterByClusterID( org_id: $org_id cluster_id: $cluster_id) {
+              deletedClusterCount
+              deletedResourceCount
+          }
+        }
+    `,
+        variables,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+  const deleteClusters = async (token, variables) =>
+    axios.post(
+      grahqlUrl,
+      {
+        query: `
+          mutation($org_id: String!) {
+            deleteClusters( org_id: $org_id ) {
+              deletedClusterCount
+              deletedResourceCount
+          }
+        }
+    `,
+        variables,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
   return {
     byClusterID,
     byClusterIDDistributed,
@@ -254,6 +296,8 @@ const clusterFunc = grahqlUrl => {
     kubeVersionCountDistributed,
     zombies,
     zombiesDistributed,
+    deleteClusterByClusterID,
+    deleteClusters,
   };
 };
 

--- a/app/apollo/test/data/local/cluster.spec.root.json
+++ b/app/apollo/test/data/local/cluster.spec.root.json
@@ -1,0 +1,7 @@
+{
+    "username": "root",
+    "email": "root@us.ibm.com",
+    "password": "password123",
+    "org_name": "org_01",
+    "role": "ADMIN"
+}

--- a/app/apollo/test/data/passport.local/cluster.spec.org_01.json
+++ b/app/apollo/test/data/passport.local/cluster.spec.org_01.json
@@ -1,4 +1,4 @@
 {
-    "type": "local",
+    "type": "passport.local",
     "name": "org_01"
 }

--- a/app/apollo/test/data/passport.local/cluster.spec.org_77.json
+++ b/app/apollo/test/data/passport.local/cluster.spec.org_77.json
@@ -1,4 +1,4 @@
 {
-    "type": "local",
+    "type": "passport.local",
     "name": "org_77"
 }

--- a/app/apollo/test/data/passport.local/cluster.spec.root.json
+++ b/app/apollo/test/data/passport.local/cluster.spec.root.json
@@ -1,0 +1,8 @@
+{
+    "type": "passport.local",
+    "username": "root",
+    "email": "root@us.ibm.com",
+    "password": "password123",
+    "org_name": "org_01",
+    "role": "ADMIN"
+}

--- a/app/apollo/test/data/passport.local/organization.spec.org_01.json
+++ b/app/apollo/test/data/passport.local/organization.spec.org_01.json
@@ -1,4 +1,4 @@
 {
-    "type": "local",
+    "type": "passport.local",
     "name": "org_01"
 }

--- a/app/apollo/test/data/passport.local/resource.spec.org_01.json
+++ b/app/apollo/test/data/passport.local/resource.spec.org_01.json
@@ -1,4 +1,4 @@
 {
-    "type": "local",
+    "type": "passport.local",
     "name": "org_01"
 }

--- a/app/apollo/test/data/passport.local/resource.spec.org_02.json
+++ b/app/apollo/test/data/passport.local/resource.spec.org_02.json
@@ -1,4 +1,4 @@
 {
-    "type": "local",
+    "type": "passport.local",
     "name": "org_02"
 }

--- a/app/apollo/test/data/passport.local/resource.spec.shouldNotMatchAny.json
+++ b/app/apollo/test/data/passport.local/resource.spec.shouldNotMatchAny.json
@@ -1,4 +1,4 @@
 {
-    "type": "local",
+    "type": "passport.local",
     "name": "should_not_match_any"
 }

--- a/app/apollo/test/data/passport.local/resourceDistributed.spec.org_01.json
+++ b/app/apollo/test/data/passport.local/resourceDistributed.spec.org_01.json
@@ -1,4 +1,4 @@
 {
-    "type": "local",
+    "type": "passport.local",
     "name": "org_01"
 }

--- a/app/apollo/test/data/passport.local/resourceDistributed.spec.org_02.json
+++ b/app/apollo/test/data/passport.local/resourceDistributed.spec.org_02.json
@@ -1,4 +1,4 @@
 {
-    "type": "local",
+    "type": "passport.local",
     "name": "org_02"
 }

--- a/app/apollo/test/data/passport.local/user.spec.org_01.json
+++ b/app/apollo/test/data/passport.local/user.spec.org_01.json
@@ -1,4 +1,4 @@
 {
-    "type": "local",
+    "type": "passport.local",
     "name": "org_01"
 }


### PR DESCRIPTION
https://github.com/razee-io/Razeedash-api/issues/289

add follow 2 apis and test cases:

mutation {
  deleteClusterByClusterID(org_id: "0c27e376-a36d-4ee0-ba90-fed4ce7988b1"
  cluster_id: "4f1a4a82-879c-4f01-be87-0312eeec5893") {
    deletedClusterCount
    deletedResourceCount
  }
}

mutation {
  deleteClusters (org_id: "0c27e376-a36d-4ee0-ba90-fed4ce7988b1") {
    deletedClusterCount
    deletedResourceCount
  }
}
