### PR TITLE
Improve performance of me query and move functionality into auth models

### DIFF
--- a/app/apollo/models/user.local.schema.js
+++ b/app/apollo/models/user.local.schema.js
@@ -158,22 +158,22 @@ UserLocalSchema.statics.createToken = async (user, secret, expiresIn) => {
 };
 
 UserLocalSchema.statics.getCurrentUser = ({me , req_id, logger}) => {
-    let result = me;
-    if (result != null) {
-      result = {
-        type: me.type,
-        id: me._id,
-        email: me.email,
-        identifier: me.identifier,
-        org_id: me.org_id,
-        role: me.role,
-        meta: me.meta,
-      };
-    } else {
-        logger.debug(`Can not locate the user for the user _id: ${me._id} for the request ${req_id}`);
-    }
-    return result;
-  };
+  let result = me;
+  if (result != null) {
+    result = {
+      type: me.type,
+      id: me._id,
+      email: me.email,
+      identifier: me.identifier,
+      org_id: me.org_id,
+      role: me.role,
+      meta: me.meta,
+    };
+  } else {
+    logger.debug(`Can not locate the user for the user _id: ${me._id} for the request ${req_id}`);
+  }
+  return result;
+};
 
 UserLocalSchema.statics.signUp = async (models, args, secret, context) => {
   logger.debug({ req_id: context.req_id }, `local signUp ${args}`);

--- a/app/apollo/models/user.local.schema.js
+++ b/app/apollo/models/user.local.schema.js
@@ -27,134 +27,135 @@ const { getBunyanConfig } = require('../../utils/bunyan');
 
 const SECRET = require('./const').SECRET;
 
-const logger = bunyan.createLogger(getBunyanConfig('apollo/models/user.local.schema'));
+const logger = bunyan.createLogger(
+  getBunyanConfig('apollo/models/user.local.schema'),
+);
 
 const UserLocalSchema = new mongoose.Schema({
-    _id: {
-        type: String,
+  _id: {
+    type: String,
+  },
+  type: {
+    type: String,
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now,
+  },
+  profile: {
+    currentOrgName: {
+      type: String,
     },
-    type: {
-        type: String,
-    },
-    createdAt: {
-        type: Date,
-        default: Date.now,
-    },
-    profile: {
-        currentOrgName: {
-            type: String,
-        },
-    },
+  },
 
-    services: {
-        local: {
-            username: {
-                type: String,
-                unique: true,
-                required: true,
-            },
-            email: {
-                type: String,
-                unique: true,
-                validate: [isEmail, 'No valid email address provided.'],
-            },
-            password: {
-                type: String,
-                required: true,
-                minlength: 7,
-                maxlength: 42,
-            },
+  services: {
+    local: {
+      username: {
+        type: String,
+        unique: true,
+        required: true,
+      },
+      email: {
+        type: String,
+        unique: true,
+        validate: [isEmail, 'No valid email address provided.'],
+      },
+      password: {
+        type: String,
+        required: true,
+        minlength: 7,
+        maxlength: 42,
+      },
+    },
+  },
+  meta: {
+    orgs: [
+      {
+        _id: {
+          type: String,
         },
-    },
-    meta: {
-        orgs: [
-            {
-                _id: {
-                    type: String,
-                },
-                role: {
-                    type: String,
-                },
-            },
-        ],
-    },
+        role: {
+          type: String,
+        },
+      },
+    ],
+  },
 });
 
 async function getOrCreateOrganization(models, args) {
-    const orgName = args.org_name || 'default_local_org';
-    const org = await models.Organization.findOne({ name: orgName });
-    if (org) return org;
-    if (models.OrganizationDistributed) {
-        const orgArray = await Promise.all(
-            models.OrganizationDistributed.map((od) => {
-                return od.createLocalOrg({
-                    _id: uuid(),
-                    type: 'local',
-                    name: orgName,
-                });
-            })
-        );
-        return orgArray[0];
-    }
-    return models.Organization.createLocalOrg({
-        _id: uuid(),
-        type: 'local',
-        name: orgName,
-    });
+  const orgName = args.org_name || 'default_local_org';
+  const org = await models.Organization.findOne({ name: orgName });
+  if (org) return org;
+  if (models.OrganizationDistributed) {
+    const orgArray = await Promise.all(
+      models.OrganizationDistributed.map(od => {
+        return od.createLocalOrg({
+          _id: uuid(),
+          type: 'local',
+          name: orgName,
+        });
+      }),
+    );
+    return orgArray[0];
+  }
+  return models.Organization.createLocalOrg({
+    _id: uuid(),
+    type: 'local',
+    name: orgName,
+  });
 }
 
-UserLocalSchema.statics.createUser = async function (models, args) {
-    const org = await getOrCreateOrganization(models, args);
+UserLocalSchema.statics.createUser = async function(models, args) {
+  const org = await getOrCreateOrganization(models, args);
 
-    const user = await this.create({
-        _id: uuid(),
-        type: 'local',
-        services: {
-            local: {
-                username: args.username,
-                email: args.email,
-                password: args.password,
-            },
+  const user = await this.create({
+    _id: uuid(),
+    type: 'local',
+    services: {
+      local: {
+        username: args.username,
+        email: args.email,
+        password: args.password,
+      },
+    },
+    meta: {
+      orgs: [
+        {
+          _id: org._id,
+          name: org.name,
+          role: args.role === 'ADMIN' ? 'ADMIN' : 'READER',
         },
-        meta: {
-            orgs: [
-                {
-                    _id: org._id,
-                    name: org.name,
-                    role: args.role === 'ADMIN' ? 'ADMIN' : 'READER',
-                },
-            ],
-        },
-    });
-    return user;
+      ],
+    },
+  });
+  return user;
 };
 
-UserLocalSchema.statics.findByLogin = async function (login) {
-    let user = await this.findOne({
-        'services.local.username': login,
-    });
-    if (!user) {
-        user = await this.findOne({ 'services.local.email': login });
-    }
-    return user;
+UserLocalSchema.statics.findByLogin = async function(login) {
+  let user = await this.findOne({
+    'services.local.username': login,
+  });
+  if (!user) {
+    user = await this.findOne({ 'services.local.email': login });
+  }
+  return user;
 };
 
 UserLocalSchema.statics.createToken = async (user, secret, expiresIn) => {
-    const claim = {
-        _id: user._id,
-        type: user.type,
-        email: user.services.local.email,
-        identifier: user.services.local.email,
-        username: user.services.local.username,
-        role: user.meta.orgs[0].role,
-        org_id: user.meta.orgs[0]._id,
-        meta: user.meta,
-    };
-    return jwt.sign(claim, secret, {
-        expiresIn,
-    });
+  const claim = {
+    _id: user._id,
+    type: user.type,
+    email: user.services.local.email,
+    identifier: user.services.local.email,
+    username: user.services.local.username,
+    role: user.meta.orgs[0].role,
+    org_id: user.meta.orgs[0]._id,
+    meta: user.meta,
+  };
+  return jwt.sign(claim, secret, {
+    expiresIn,
+  });
 };
-
 
 UserLocalSchema.statics.getCurrentUser = ({me , req_id, logger}) => {
     let result = me;
@@ -163,7 +164,7 @@ UserLocalSchema.statics.getCurrentUser = ({me , req_id, logger}) => {
         type: me.type,
         id: me._id,
         email: me.email,
-        identifier: me.identifier, 
+        identifier: me.identifier,
         org_id: me.org_id,
         role: me.role,
         meta: me.meta,
@@ -175,149 +176,160 @@ UserLocalSchema.statics.getCurrentUser = ({me , req_id, logger}) => {
   };
 
 UserLocalSchema.statics.signUp = async (models, args, secret, context) => {
-    logger.debug({ req_id: context.req_id }, `local signUp ${args}`);
-    if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
-        const user = await models.User.createUser(models, args);
-        return { token: models.User.createToken(user, secret, '240m') };
-    }
-    logger.warn({ req_id: context.req_id }, `Current authorization model ${AUTH_MODEL} does not support this option.`);
-    throw new AuthenticationError(`Current authorization model ${AUTH_MODEL} does not support this option.`);
+  logger.debug({ req_id: context.req_id }, `local signUp ${args}`);
+  if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
+    const user = await models.User.createUser(models, args);
+    return { token: models.User.createToken(user, secret, '240m') };
+  }
+  logger.warn(
+    { req_id: context.req_id },
+    `Current authorization model ${AUTH_MODEL} does not support this option.`
+  );
+  throw new AuthenticationError(
+    `Current authorization model ${AUTH_MODEL} does not support this option.`,
+  );
 };
 
 UserLocalSchema.statics.signIn = async (models, login, password, secret, context) => {
-    logger.debug({ login, req_id: context.req_id }, 'local signIn enter');
-    if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
-        const user = await models.User.findByLogin(login);
-        if (!user) {
-            logger.warn({ req_id: context.req_id }, 'No user found with this login credentials.');
-            throw new UserInputError('No user found with this login credentials.');
-        }
-        const isValid = await user.validatePassword(password);
-        if (!isValid) {
-            logger.warn({ req_id: context.req_id }, 'Invalid password.');
-            throw new AuthenticationError('Invalid password.');
-        }
-        return { token: models.User.createToken(user, secret, '240m') };
+  logger.debug({login, req_id: context.req_id}, 'local signIn enter');
+  if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
+    const user = await models.User.findByLogin(login);
+    if (!user) {
+      logger.warn({ req_id: context.req_id },'No user found with this login credentials.');
+      throw new UserInputError('No user found with this login credentials.');
     }
-    logger.warn({ req_id: context.req_id }, `Current authorization model ${AUTH_MODEL} does not support this option.`);
-    throw new AuthenticationError(`Current authorization model ${AUTH_MODEL} does not support this option.`);
+    const isValid = await user.validatePassword(password);
+    if (!isValid) {
+      logger.warn({ req_id: context.req_id }, 'Invalid password.');
+      throw new AuthenticationError('Invalid password.');
+    }
+    return { token: models.User.createToken(user, secret, '240m') };
+  }
+  logger.warn({ req_id: context.req_id },`Current authorization model ${AUTH_MODEL} does not support this option.`);
+  throw new AuthenticationError(
+    `Current authorization model ${AUTH_MODEL} does not support this option.`,
+  );
 };
 
-UserLocalSchema.statics.getMeFromRequest = async function (req, context) {
-    if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
-        const { req_id, logger } = context;
-        let token = req.headers['authorization'];
-        if (token) {
-            if (token.startsWith('Bearer ')) {
-                // Remove Bearer from string
-                token = token.slice(7, token.length);
-            }
-            try {
-                return jwt.verify(token, SECRET);
-            } catch (e) {
-                logger.warn({ req_id }, 'getMeFromRequest Session expired');
-                throw new AuthenticationError('Your session expired. Sign in again.');
-            }
-        }
+UserLocalSchema.statics.getMeFromRequest = async function(req, context) {
+  if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
+    const {req_id, logger} = context;
+    let token = req.headers['authorization'];
+    if (token) {
+      if (token.startsWith('Bearer ')) {
+        // Remove Bearer from string
+        token = token.slice(7, token.length);
+      }
+      try {
+        return jwt.verify(token, SECRET);
+      } catch (e) {
+        logger.warn({ req_id }, 'getMeFromRequest Session expired');
+        throw new AuthenticationError('Your session expired. Sign in again.');
+      }
     }
-    return null;
+  }
+  return null;
 };
 
-UserLocalSchema.statics.getMeFromConnectionParams = async function (connectionParams, context) {
-    if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
-        const { req_id, logger } = context;
-        let token = connectionParams['authorization'];
-        if (token) {
-            if (token.startsWith('Bearer ')) {
-                // Remove Bearer from string
-                token = token.slice(7, token.length);
-            }
-            try {
-                return jwt.verify(token, SECRET);
-            } catch (e) {
-                logger.warn({ req_id }, 'getMeFromConnectionParams Session expired');
-                throw new AuthenticationError('Your session expired. Sign in again');
-            }
-        }
+UserLocalSchema.statics.getMeFromConnectionParams = async function(
+  connectionParams,
+  context
+) {
+  if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
+    const {req_id, logger} = context;
+    let token = connectionParams['authorization'];
+    if (token) {
+      if (token.startsWith('Bearer ')) {
+        // Remove Bearer from string
+        token = token.slice(7, token.length);
+      }
+      try {
+        return jwt.verify(token, SECRET);
+      } catch (e) {
+        logger.warn({ req_id }, 'getMeFromConnectionParams Session expired');
+        throw new AuthenticationError('Your session expired. Sign in again');
+      }
     }
-    return null;
+  }
+  return null;
 };
 
-UserLocalSchema.statics.isAuthorized = async function (me, orgId, action, type, attributes, context) {
-    const { req_id, logger } = context;
-    logger.debug({ req_id }, `local isAuthorized ${me} ${action} ${type} ${attributes}`);
+UserLocalSchema.statics.isAuthorized = async function(me, orgId, action, type, attributes, context) {
+  const { req_id, logger } = context;
+  logger.debug({ req_id },`local isAuthorized ${me} ${action} ${type} ${attributes}`);
 
-    const orgMeta = me.meta.orgs.find((o) => {
-        return o._id == orgId;
-    });
-    if (!orgMeta) {
-        return false;
-    }
-    if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
-        if (action === ACTIONS.READ) {
-            return !!orgMeta;
-        }
-        if (action === ACTIONS.MANAGE || action === ACTIONS.WRITE) {
-            return orgMeta.role === 'ADMIN';
-        }
-    }
+  const orgMeta = me.meta.orgs.find((o)=>{
+    return (o._id == orgId);
+  });
+  if(!orgMeta){
     return false;
-};
-
-UserLocalSchema.statics.getOrgs = async function (context) {
-    const results = [];
-    const { models, me } = context;
-    if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
-        const meFromDB = await models.User.findOne({ _id: me._id });
-        if (meFromDB && meFromDB.meta.orgs) {
-            // eslint-disable-next-line no-restricted-syntax
-            for (const org of meFromDB.meta.orgs) {
-                // eslint-disable-next-line no-await-in-loop
-                const orgFromDB = await models.Organization.findOne({ _id: org._id });
-                if (orgFromDB) {
-                    results.push({ name: orgFromDB.name, _id: org._id });
-                }
-            }
-        }
+  }
+  if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
+    if (action === ACTIONS.READ) {
+      return !!orgMeta;
     }
-    return results;
+    if (action === ACTIONS.MANAGE || action === ACTIONS.WRITE) {
+      return orgMeta.role === 'ADMIN';
+    }
+  }
+  return false;
 };
 
-UserLocalSchema.pre('save', async function () {
-    this.services.local.password = await this.generatePasswordHash();
+UserLocalSchema.statics.getOrgs = async function(context) {
+  const results = [];
+  const { models, me } = context;
+  if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
+    const meFromDB = await models.User.findOne({ _id: me._id });
+    if (meFromDB && meFromDB.meta.orgs) {
+      // eslint-disable-next-line no-restricted-syntax
+      for (const org of meFromDB.meta.orgs) {
+        // eslint-disable-next-line no-await-in-loop
+        const orgFromDB = await models.Organization.findOne({ _id: org._id });
+        if (orgFromDB) {
+          results.push({ name: orgFromDB.name, _id: org._id });
+        }
+      }
+    }
+  }
+  return results;
+};
+
+UserLocalSchema.pre('save', async function() {
+  this.services.local.password = await this.generatePasswordHash();
 });
 
-UserLocalSchema.methods.generatePasswordHash = function () {
-    const saltRounds = 10;
-    return bcrypt.hashSync(this.services.local.password, saltRounds);
+UserLocalSchema.methods.generatePasswordHash = function() {
+  const saltRounds = 10;
+  return bcrypt.hashSync(this.services.local.password, saltRounds);
 };
 
-UserLocalSchema.methods.validatePassword = function (password) {
-    return bcrypt.compareSync(password, this.services.local.password);
+UserLocalSchema.methods.validatePassword = function(password) {
+  return bcrypt.compareSync(password, this.services.local.password);
 };
 
-UserLocalSchema.methods.getId = async function () {
-    return this._id;
+UserLocalSchema.methods.getId = async function() {
+  return this._id;
 };
 
-UserLocalSchema.methods.getEmail = async function () {
-    return this.services.local.email;
+UserLocalSchema.methods.getEmail = async function() {
+  return this.services.local.email;
 };
 
-UserLocalSchema.methods.getIdentifier = async function () {
-    return this.services.local.email;
+UserLocalSchema.methods.getIdentifier = async function() {
+  return this.services.local.email;
 };
 
-UserLocalSchema.methods.getMeta = async function () {
-    return this.meta;
+UserLocalSchema.methods.getMeta = async function() {
+  return this.meta;
 };
 
-UserLocalSchema.methods.getCurrentOrgId = async function () {
-    return this.meta.orgs[0]._id;
+UserLocalSchema.methods.getCurrentOrgId = async function() {
+  return this.meta.orgs[0]._id;
 };
 
-UserLocalSchema.methods.getCurrentRole = async function () {
-    return this.meta.orgs[0].role;
+UserLocalSchema.methods.getCurrentRole = async function() {
+  return this.meta.orgs[0].role;
 };
 
 module.exports = UserLocalSchema;
+

--- a/app/apollo/models/user.local.schema.js
+++ b/app/apollo/models/user.local.schema.js
@@ -27,291 +27,297 @@ const { getBunyanConfig } = require('../../utils/bunyan');
 
 const SECRET = require('./const').SECRET;
 
-const logger = bunyan.createLogger(
-  getBunyanConfig('apollo/models/user.local.schema'),
-);
+const logger = bunyan.createLogger(getBunyanConfig('apollo/models/user.local.schema'));
 
 const UserLocalSchema = new mongoose.Schema({
-  _id: {
-    type: String,
-  },
-  type: {
-    type: String,
-  },
-  createdAt: {
-    type: Date,
-    default: Date.now,
-  },
-  profile: {
-    currentOrgName: {
-      type: String,
+    _id: {
+        type: String,
     },
-  },
+    type: {
+        type: String,
+    },
+    createdAt: {
+        type: Date,
+        default: Date.now,
+    },
+    profile: {
+        currentOrgName: {
+            type: String,
+        },
+    },
 
-  services: {
-    local: {
-      username: {
-        type: String,
-        unique: true,
-        required: true,
-      },
-      email: {
-        type: String,
-        unique: true,
-        validate: [isEmail, 'No valid email address provided.'],
-      },
-      password: {
-        type: String,
-        required: true,
-        minlength: 7,
-        maxlength: 42,
-      },
+    services: {
+        local: {
+            username: {
+                type: String,
+                unique: true,
+                required: true,
+            },
+            email: {
+                type: String,
+                unique: true,
+                validate: [isEmail, 'No valid email address provided.'],
+            },
+            password: {
+                type: String,
+                required: true,
+                minlength: 7,
+                maxlength: 42,
+            },
+        },
     },
-  },
-  meta: {
-    orgs: [
-      {
-        _id: {
-          type: String,
-        },
-        role: {
-          type: String,
-        },
-      },
-    ],
-  },
+    meta: {
+        orgs: [
+            {
+                _id: {
+                    type: String,
+                },
+                role: {
+                    type: String,
+                },
+            },
+        ],
+    },
 });
 
 async function getOrCreateOrganization(models, args) {
-  const orgName = args.org_name || 'default_local_org';
-  const org = await models.Organization.findOne({ name: orgName });
-  if (org) return org;
-  if (models.OrganizationDistributed) {
-    const orgArray = await Promise.all(
-      models.OrganizationDistributed.map(od => {
-        return od.createLocalOrg({
-          _id: uuid(),
-          type: 'local',
-          name: orgName,
-        });
-      }),
-    );
-    return orgArray[0];
-  }
-  return models.Organization.createLocalOrg({
-    _id: uuid(),
-    type: 'local',
-    name: orgName,
-  });
+    const orgName = args.org_name || 'default_local_org';
+    const org = await models.Organization.findOne({ name: orgName });
+    if (org) return org;
+    if (models.OrganizationDistributed) {
+        const orgArray = await Promise.all(
+            models.OrganizationDistributed.map((od) => {
+                return od.createLocalOrg({
+                    _id: uuid(),
+                    type: 'local',
+                    name: orgName,
+                });
+            })
+        );
+        return orgArray[0];
+    }
+    return models.Organization.createLocalOrg({
+        _id: uuid(),
+        type: 'local',
+        name: orgName,
+    });
 }
 
-UserLocalSchema.statics.createUser = async function(models, args) {
-  const org = await getOrCreateOrganization(models, args);
+UserLocalSchema.statics.createUser = async function (models, args) {
+    const org = await getOrCreateOrganization(models, args);
 
-  const user = await this.create({
-    _id: uuid(),
-    type: 'local',
-    services: {
-      local: {
-        username: args.username,
-        email: args.email,
-        password: args.password,
-      },
-    },
-    meta: {
-      orgs: [
-        {
-          _id: org._id,
-          name: org.name,
-          role: args.role === 'ADMIN' ? 'ADMIN' : 'READER',
+    const user = await this.create({
+        _id: uuid(),
+        type: 'local',
+        services: {
+            local: {
+                username: args.username,
+                email: args.email,
+                password: args.password,
+            },
         },
-      ],
-    },
-  });
-  return user;
+        meta: {
+            orgs: [
+                {
+                    _id: org._id,
+                    name: org.name,
+                    role: args.role === 'ADMIN' ? 'ADMIN' : 'READER',
+                },
+            ],
+        },
+    });
+    return user;
 };
 
-UserLocalSchema.statics.findByLogin = async function(login) {
-  let user = await this.findOne({
-    'services.local.username': login,
-  });
-  if (!user) {
-    user = await this.findOne({ 'services.local.email': login });
-  }
-  return user;
+UserLocalSchema.statics.findByLogin = async function (login) {
+    let user = await this.findOne({
+        'services.local.username': login,
+    });
+    if (!user) {
+        user = await this.findOne({ 'services.local.email': login });
+    }
+    return user;
 };
 
 UserLocalSchema.statics.createToken = async (user, secret, expiresIn) => {
-  const claim = {
-    _id: user._id,
-    type: user.type,
-    email: user.services.local.email,
-    identifier: user.services.local.email,
-    username: user.services.local.username,
-    role: user.meta.orgs[0].role,
-    org_id: user.meta.orgs[0]._id,
-    meta: user.meta,
-  };
-  return jwt.sign(claim, secret, {
-    expiresIn,
-  });
+    const claim = {
+        _id: user._id,
+        type: user.type,
+        email: user.services.local.email,
+        identifier: user.services.local.email,
+        username: user.services.local.username,
+        role: user.meta.orgs[0].role,
+        org_id: user.meta.orgs[0]._id,
+        meta: user.meta,
+    };
+    return jwt.sign(claim, secret, {
+        expiresIn,
+    });
 };
 
+
+UserLocalSchema.statics.getCurrentUser = ({me , req_id, logger}) => {
+    let result = me;
+    if (result != null) {
+      result = {
+        type: me.type,
+        id: me._id,
+        email: me.email,
+        identifier: me.identifier, 
+        org_id: me.org_id,
+        role: me.role,
+        meta: me.meta,
+      };
+    } else {
+        logger.debug(`Can not locate the user for the user _id: ${me._id} for the request ${req_id}`);
+    }
+    return result;
+  };
+
 UserLocalSchema.statics.signUp = async (models, args, secret, context) => {
-  logger.debug({ req_id: context.req_id }, `local signUp ${args}`);
-  if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
-    const user = await models.User.createUser(models, args);
-    return { token: models.User.createToken(user, secret, '240m') };
-  }
-  logger.warn(
-    { req_id: context.req_id },
-    `Current authorization model ${AUTH_MODEL} does not support this option.`
-  );
-  throw new AuthenticationError(
-    `Current authorization model ${AUTH_MODEL} does not support this option.`,
-  );
+    logger.debug({ req_id: context.req_id }, `local signUp ${args}`);
+    if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
+        const user = await models.User.createUser(models, args);
+        return { token: models.User.createToken(user, secret, '240m') };
+    }
+    logger.warn({ req_id: context.req_id }, `Current authorization model ${AUTH_MODEL} does not support this option.`);
+    throw new AuthenticationError(`Current authorization model ${AUTH_MODEL} does not support this option.`);
 };
 
 UserLocalSchema.statics.signIn = async (models, login, password, secret, context) => {
-  logger.debug({login, req_id: context.req_id}, 'local signIn enter');
-  if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
-    const user = await models.User.findByLogin(login);
-    if (!user) {
-      logger.warn({ req_id: context.req_id },'No user found with this login credentials.');
-      throw new UserInputError('No user found with this login credentials.');
-    }
-    const isValid = await user.validatePassword(password);
-    if (!isValid) {
-      logger.warn({ req_id: context.req_id }, 'Invalid password.');
-      throw new AuthenticationError('Invalid password.');
-    }
-    return { token: models.User.createToken(user, secret, '240m') };
-  }
-  logger.warn({ req_id: context.req_id },`Current authorization model ${AUTH_MODEL} does not support this option.`);
-  throw new AuthenticationError(
-    `Current authorization model ${AUTH_MODEL} does not support this option.`,
-  );
-};
-
-UserLocalSchema.statics.getMeFromRequest = async function(req, context) {
-  if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
-    const {req_id, logger} = context;
-    let token = req.headers['authorization'];
-    if (token) {
-      if (token.startsWith('Bearer ')) {
-        // Remove Bearer from string
-        token = token.slice(7, token.length);
-      }
-      try {
-        return jwt.verify(token, SECRET);
-      } catch (e) {
-        logger.warn({ req_id }, 'getMeFromRequest Session expired');
-        throw new AuthenticationError('Your session expired. Sign in again.');
-      }
-    }
-  }
-  return null;
-};
-
-UserLocalSchema.statics.getMeFromConnectionParams = async function(
-  connectionParams,
-  context
-) {
-  if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
-    const {req_id, logger} = context;
-    let token = connectionParams['authorization'];
-    if (token) {
-      if (token.startsWith('Bearer ')) {
-        // Remove Bearer from string
-        token = token.slice(7, token.length);
-      }
-      try {
-        return jwt.verify(token, SECRET);
-      } catch (e) {
-        logger.warn({ req_id }, 'getMeFromConnectionParams Session expired');
-        throw new AuthenticationError('Your session expired. Sign in again');
-      }
-    }
-  }
-  return null;
-};
-
-UserLocalSchema.statics.isAuthorized = async function(me, orgId, action, type, attributes, context) {
-  const { req_id, logger } = context;
-  logger.debug({ req_id },`local isAuthorized ${me} ${action} ${type} ${attributes}`);
-
-  const orgMeta = me.meta.orgs.find((o)=>{
-    return (o._id == orgId);
-  });
-  if(!orgMeta){
-    return false;
-  }
-  if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
-    if (action === ACTIONS.READ) {
-      return !!orgMeta;
-    }
-    if (action === ACTIONS.MANAGE || action === ACTIONS.WRITE) {
-      return orgMeta.role === 'ADMIN';
-    }
-  }
-  return false;
-};
-
-UserLocalSchema.statics.getOrgs = async function(context) {
-  const results = [];
-  const { models, me } = context;
-  if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
-    const meFromDB = await models.User.findOne({ _id: me._id });
-    if (meFromDB && meFromDB.meta.orgs) {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const org of meFromDB.meta.orgs) {
-        // eslint-disable-next-line no-await-in-loop
-        const orgFromDB = await models.Organization.findOne({ _id: org._id });
-        if (orgFromDB) {
-          results.push({ name: orgFromDB.name, _id: org._id });
+    logger.debug({ login, req_id: context.req_id }, 'local signIn enter');
+    if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
+        const user = await models.User.findByLogin(login);
+        if (!user) {
+            logger.warn({ req_id: context.req_id }, 'No user found with this login credentials.');
+            throw new UserInputError('No user found with this login credentials.');
         }
-      }
+        const isValid = await user.validatePassword(password);
+        if (!isValid) {
+            logger.warn({ req_id: context.req_id }, 'Invalid password.');
+            throw new AuthenticationError('Invalid password.');
+        }
+        return { token: models.User.createToken(user, secret, '240m') };
     }
-  }
-  return results;
+    logger.warn({ req_id: context.req_id }, `Current authorization model ${AUTH_MODEL} does not support this option.`);
+    throw new AuthenticationError(`Current authorization model ${AUTH_MODEL} does not support this option.`);
 };
 
-UserLocalSchema.pre('save', async function() {
-  this.services.local.password = await this.generatePasswordHash();
+UserLocalSchema.statics.getMeFromRequest = async function (req, context) {
+    if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
+        const { req_id, logger } = context;
+        let token = req.headers['authorization'];
+        if (token) {
+            if (token.startsWith('Bearer ')) {
+                // Remove Bearer from string
+                token = token.slice(7, token.length);
+            }
+            try {
+                return jwt.verify(token, SECRET);
+            } catch (e) {
+                logger.warn({ req_id }, 'getMeFromRequest Session expired');
+                throw new AuthenticationError('Your session expired. Sign in again.');
+            }
+        }
+    }
+    return null;
+};
+
+UserLocalSchema.statics.getMeFromConnectionParams = async function (connectionParams, context) {
+    if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
+        const { req_id, logger } = context;
+        let token = connectionParams['authorization'];
+        if (token) {
+            if (token.startsWith('Bearer ')) {
+                // Remove Bearer from string
+                token = token.slice(7, token.length);
+            }
+            try {
+                return jwt.verify(token, SECRET);
+            } catch (e) {
+                logger.warn({ req_id }, 'getMeFromConnectionParams Session expired');
+                throw new AuthenticationError('Your session expired. Sign in again');
+            }
+        }
+    }
+    return null;
+};
+
+UserLocalSchema.statics.isAuthorized = async function (me, orgId, action, type, attributes, context) {
+    const { req_id, logger } = context;
+    logger.debug({ req_id }, `local isAuthorized ${me} ${action} ${type} ${attributes}`);
+
+    const orgMeta = me.meta.orgs.find((o) => {
+        return o._id == orgId;
+    });
+    if (!orgMeta) {
+        return false;
+    }
+    if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
+        if (action === ACTIONS.READ) {
+            return !!orgMeta;
+        }
+        if (action === ACTIONS.MANAGE || action === ACTIONS.WRITE) {
+            return orgMeta.role === 'ADMIN';
+        }
+    }
+    return false;
+};
+
+UserLocalSchema.statics.getOrgs = async function (context) {
+    const results = [];
+    const { models, me } = context;
+    if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
+        const meFromDB = await models.User.findOne({ _id: me._id });
+        if (meFromDB && meFromDB.meta.orgs) {
+            // eslint-disable-next-line no-restricted-syntax
+            for (const org of meFromDB.meta.orgs) {
+                // eslint-disable-next-line no-await-in-loop
+                const orgFromDB = await models.Organization.findOne({ _id: org._id });
+                if (orgFromDB) {
+                    results.push({ name: orgFromDB.name, _id: org._id });
+                }
+            }
+        }
+    }
+    return results;
+};
+
+UserLocalSchema.pre('save', async function () {
+    this.services.local.password = await this.generatePasswordHash();
 });
 
-UserLocalSchema.methods.generatePasswordHash = function() {
-  const saltRounds = 10;
-  return bcrypt.hashSync(this.services.local.password, saltRounds);
+UserLocalSchema.methods.generatePasswordHash = function () {
+    const saltRounds = 10;
+    return bcrypt.hashSync(this.services.local.password, saltRounds);
 };
 
-UserLocalSchema.methods.validatePassword = function(password) {
-  return bcrypt.compareSync(password, this.services.local.password);
+UserLocalSchema.methods.validatePassword = function (password) {
+    return bcrypt.compareSync(password, this.services.local.password);
 };
 
-UserLocalSchema.methods.getId = async function() {
-  return this._id;
+UserLocalSchema.methods.getId = async function () {
+    return this._id;
 };
 
-UserLocalSchema.methods.getEmail = async function() {
-  return this.services.local.email;
+UserLocalSchema.methods.getEmail = async function () {
+    return this.services.local.email;
 };
 
-UserLocalSchema.methods.getIdentifier = async function() {
-  return this.services.local.email;
+UserLocalSchema.methods.getIdentifier = async function () {
+    return this.services.local.email;
 };
 
-UserLocalSchema.methods.getMeta = async function() {
-  return this.meta;
+UserLocalSchema.methods.getMeta = async function () {
+    return this.meta;
 };
 
-UserLocalSchema.methods.getCurrentOrgId = async function() {
-  return this.meta.orgs[0]._id;
+UserLocalSchema.methods.getCurrentOrgId = async function () {
+    return this.meta.orgs[0]._id;
 };
 
-UserLocalSchema.methods.getCurrentRole = async function() {
-  return this.meta.orgs[0].role;
+UserLocalSchema.methods.getCurrentRole = async function () {
+    return this.meta.orgs[0].role;
 };
 
 module.exports = UserLocalSchema;
-

--- a/app/apollo/models/user.passport.local.schema.js
+++ b/app/apollo/models/user.passport.local.schema.js
@@ -162,6 +162,26 @@ UserPassportLocalSchema.statics.createToken = async (
   });
 };
 
+UserPassportLocalSchema.statics.getCurrentUser = ({me , req_id, logger}) => {
+  let result = me;
+  if (result != null) {
+    result = {
+      type: me.type,
+      id: me._id,
+      email: me.email,
+      identifier: me.identifier, 
+      org_id: me.org_id,
+      role: me.role,
+      meta: me.meta,
+    };
+  } else {
+      logger.debug(`Can not locate the user for the user _id: ${me._id} for the request ${req_id}`);
+  }
+  return result;
+};
+
+
+
 UserPassportLocalSchema.statics.signUp = async (models, args, secret, context) => {
   logger.debug( { req_id: context.req_id }, `passport.local signUp: ${args}`);
   if (AUTH_MODEL === AUTH_MODELS.PASSPORT_LOCAL) {

--- a/app/apollo/models/user.passport.local.schema.js
+++ b/app/apollo/models/user.passport.local.schema.js
@@ -175,7 +175,7 @@ UserPassportLocalSchema.statics.getCurrentUser = ({me , req_id, logger}) => {
       meta: me.meta,
     };
   } else {
-      logger.debug(`Can not locate the user for the user _id: ${me._id} for the request ${req_id}`);
+    logger.debug(`Can not locate the user for the user _id: ${me._id} for the request ${req_id}`);
   }
   return result;
 };

--- a/app/apollo/resolvers/user.js
+++ b/app/apollo/resolvers/user.js
@@ -16,28 +16,14 @@
 
 const userResolvers = {
   Query: {
-    me: async (parent, args, { models, me , req_id, logger }) => {
+    me: async (parent, args, context) => {
+      const { models, me , req_id, logger } = context;
       if (!me) {
         logger.debug(`There is no user information on this context for the request ${req_id}`);
         return null;
       }
-      // TODO: we probably skip database query and directly return user info from
-      // JWT token.
-      let result = await models.User.findOne({ _id: me._id });
-      if (result != null) {
-        result = {
-          type: result.type,
-          id: result.getId(),
-          email: result.getEmail(),
-          identifier: typeof result.getIdentifier === 'function' ? result.getIdentifier() : null, 
-          org_id: result.getCurrentOrgId(),
-          role: result.getCurrentRole(),
-          meta: result.getMeta(),
-        };
-      } else {
-        logger.debug(`Can not locate the user for the user _id: ${me._id} for the request ${req_id}`);
-      }
-      return result;
+
+      return models.User.getCurrentUser(context);
     },
   },
 

--- a/app/apollo/test/testHelper.local.js
+++ b/app/apollo/test/testHelper.local.js
@@ -45,7 +45,7 @@ async function signInUser (models, api, userData) {
 }
 
 async function signUpUser (models, api, userData) {
-  if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
+  if (AUTH_MODEL === AUTH_MODELS.LOCAL) {   
     const result0 = await api.signUp({
       username: userData.username,
       email: userData.email,

--- a/app/apollo/test/testHelper.local.js
+++ b/app/apollo/test/testHelper.local.js
@@ -45,7 +45,7 @@ async function signInUser (models, api, userData) {
 }
 
 async function signUpUser (models, api, userData) {
-  if (AUTH_MODEL === AUTH_MODELS.LOCAL) {   
+  if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
     const result0 = await api.signUp({
       username: userData.username,
       email: userData.email,

--- a/app/apollo/test/user.spec.js
+++ b/app/apollo/test/user.spec.js
@@ -141,12 +141,13 @@ describe('user graphql', () => {
       try {
         token = await signUpUser(models, api, user02Data);
         console.log(`user01 token=${token}`);
+       
         const {
           data: {
             data: { me },
           },
         } = await api.me(token);
-        console.log(JSON.stringify(me, null, 4));
+       
         expect(me.id).to.be.a('string');
         expect(me.email).to.be.a('string');
         expect(me.org_id).to.be.a('string');


### PR DESCRIPTION
Improved the performance of the graphQL me query by not having to query the DB to return the results. The information is already supplied in an object passed in. 

Added new method in user.local.schema.js and user user.passport.local.schema.js   called getCurrentUser(). This allows for different ways to pull the information based on authorization type. 

The resolver for me now calls the getCurrentUser() method to get the information needed 