### PR TITLE
Fix: add getOrg to local and passport.local

### DIFF
--- a/app/apollo/models/user.local.schema.js
+++ b/app/apollo/models/user.local.schema.js
@@ -285,10 +285,7 @@ UserLocalSchema.statics.isAuthorized = async function(me, orgId, action, type, a
 UserLocalSchema.statics.getOrg = async function(models, me) {
   let org;
   if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
-    const meFromDB = await models.User.findOne({ _id: me._id });
-    if (meFromDB) {
-      org = await models.Organization.findOne({ orgKeys: me.orgKey }).lean();
-    }
+    org = await models.Organization.findOne({ orgKeys: me.orgKey }).lean();
   }
   return org;
 };

--- a/app/apollo/models/user.local.schema.js
+++ b/app/apollo/models/user.local.schema.js
@@ -282,6 +282,17 @@ UserLocalSchema.statics.isAuthorized = async function(me, orgId, action, type, a
   return false;
 };
 
+UserLocalSchema.statics.getOrg = async function(models, me) {
+  let org;
+  if (AUTH_MODEL === AUTH_MODELS.LOCAL) {
+    const meFromDB = await models.User.findOne({ _id: me._id });
+    if (meFromDB) {
+      org = await models.Organization.findOne({ orgKeys: me.orgKey }).lean();
+    }
+  }
+  return org;
+};
+
 UserLocalSchema.statics.getOrgs = async function(context) {
   const results = [];
   const { models, me } = context;

--- a/app/apollo/models/user.passport.local.schema.js
+++ b/app/apollo/models/user.passport.local.schema.js
@@ -281,6 +281,17 @@ UserPassportLocalSchema.statics.isAuthorized = async function(me, orgId, action,
   return false;
 };
 
+UserPassportLocalSchema.statics.getOrg = async function(models, me) {
+  let org;
+  if (AUTH_MODEL === AUTH_MODELS.PASSPORT_LOCAL) {
+    const meFromDB = await models.User.findOne({ _id: me._id });
+    if (meFromDB) {
+      org = await models.Organization.findOne({ orgKeys: me.orgKey }).lean();
+    }
+  }
+  return org;
+};
+
 UserPassportLocalSchema.statics.getOrgs = async function(context) {
   const results = [];
   const { models, me } = context;

--- a/app/apollo/models/user.passport.local.schema.js
+++ b/app/apollo/models/user.passport.local.schema.js
@@ -284,10 +284,7 @@ UserPassportLocalSchema.statics.isAuthorized = async function(me, orgId, action,
 UserPassportLocalSchema.statics.getOrg = async function(models, me) {
   let org;
   if (AUTH_MODEL === AUTH_MODELS.PASSPORT_LOCAL) {
-    const meFromDB = await models.User.findOne({ _id: me._id });
-    if (meFromDB) {
-      org = await models.Organization.findOne({ orgKeys: me.orgKey }).lean();
-    }
+    org = await models.Organization.findOne({ orgKeys: me.orgKey }).lean();
   }
   return org;
 };


### PR DESCRIPTION
The [ClusterSubscription](https://github.com/razee-io/ClusterSubscription) client calls subscriptionsByTag which calls getOrg.  Currently only the default auth model has getOrg implemented so this would cause local and passport.local users of ClusterSubscription to get errors