### PR TITLE
Update: match clusters with any tags instead of all tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,14 @@ Razeedash-API is the interface used by
 | S3_ACCESS_KEY_ID        | if S3_ENDPOINT defined | n/a |
 | S3_SECRET_ACCESS_KEY    | if S3_ENDPOINT defined | n/a |
 | S3_LOCATION_CONSTRAINT  | no                     | 'us-standard'|
-| S3_BUCKET_PREFIX        | no                     | 'razee'|
+| S3_CHANNEL_BUCKET       | no                     | 'razee'|
+| S3_RESOURCE_BUCKET      | no                     | S3_CHANNEL_BUCKET or 'razee'|
 | ORG_ADMIN_KEY           | no                     | n/a |
 | ADD_CLUSTER_WEBHOOK_URL | no                     | n/a |
 | AUTH_MODEL              | no                     | 'default' [default, local, passport.local] are supported |
 
 If S3_ENDPOINT is defined then encrypted cluster YAML is stored in S3 otherwise
 it will be stored in the mongoDB.
-
-If S3_BUCKET_PREFIX is not defined then the s3 bucket will be named `razee-<your_razee_org_id>`
 
 ORG_ADMIN_KEY is required if you plan on adding organizations using the api/v2/orgs endpoint
 

--- a/app/apollo/models/label.schema.js
+++ b/app/apollo/models/label.schema.js
@@ -21,7 +21,7 @@ const LabelSchema = new mongoose.Schema({
   _id: {
     type: String,
   },
-  orgId: {
+  org_id: {
     type: String,
   },
   name: {
@@ -46,8 +46,8 @@ LabelSchema.statics.findOrCreateList = async (models, orgId, tags, context) => {
 
   const labels = await Promise.all(tags.map(async tag => {
     return await models.Label.findOneAndUpdate (
-      {orgId, name: tag},
-      {_id: UUID(), uuid: UUID(), orgId, name: tag, owner: me._id ? me._id : 'undefined' }, 
+      {org_id: orgId, name: tag},
+      {_id: UUID(), uuid: UUID(), org_id: orgId, name: tag, owner: me._id ? me._id : 'undefined' }, 
       {new: true, upsert: true, setDefaultsOnInsert: true, useFindAndModify: false}).lean();
   }));
 
@@ -55,6 +55,6 @@ LabelSchema.statics.findOrCreateList = async (models, orgId, tags, context) => {
   return labels;
 };
 
-LabelSchema.index({ orgId: 1 }, { });
+LabelSchema.index({ org_id: 1 }, { });
 
 module.exports = LabelSchema;

--- a/app/apollo/models/user.default.schema.js
+++ b/app/apollo/models/user.default.schema.js
@@ -106,10 +106,6 @@ UserDefaultSchema.statics.isAuthorizedBatch = async function(me, orgId, objectAr
     return new Array(objectArray.length).fill(false);
   }
 
-  if (me.type === 'userToken') {
-    me = me.user;
-  }
-
   const user = await this.findOne({ apiKey: me.apiKey }).lean();
   if(!user) {
     logger.error('A user was not found for this apiKey');

--- a/app/apollo/resolvers/channel.js
+++ b/app/apollo/resolvers/channel.js
@@ -210,8 +210,8 @@ const channelResolvers = {
       let data = null;
 
       if(conf.s3.endpoint){
-        const resourceName = `${channel.name}-${name}`;
-        const bucketName = `${conf.s3.bucketPrefix}-${org_id.toLowerCase()}`;
+        const resourceName = `${org_id.toLowerCase()}-${channel.uuid}-${name}`;
+        const bucketName = `${conf.s3.channelBucket}`;
 
         const s3Client = new S3ClientClass(conf);
 

--- a/app/apollo/resolvers/common.js
+++ b/app/apollo/resolvers/common.js
@@ -43,7 +43,7 @@ const getUserTags = async (me, org_id, action, field, queryName, context) => {
   const {req_id, models, logger} = context;
 
   logger.debug({req_id, user: whoIs(me), org_id, field, action }, `getUserTags enter for ${queryName}`);
-  const labels = await models.Label.find({orgId: org_id}).lean();
+  const labels = await models.Label.find({org_id: org_id}).lean();
   const objectArray = labels.map(l => {
     return {type: TYPES.LABEL, action, uuid: l.uuid, name: l.name};
   });

--- a/app/apollo/resolvers/label.js
+++ b/app/apollo/resolvers/label.js
@@ -20,6 +20,9 @@ const {  ValidationError } = require('apollo-server');
 
 const { ACTIONS, TYPES } = require('../models/const');
 const { whoIs, validAuth, NotFoundError } = require ('./common');
+const { GraphqlPubSub } = require('../subscription');
+
+const pubSub = GraphqlPubSub.getInstance();
 
 const labelResolvers = {
   Query: {
@@ -111,6 +114,9 @@ const labelResolvers = {
           _id: UUID(),
           uuid, org_id: org_id, name, owner: me._id,
         });
+
+        pubSub.channelSubChangedFunc({org_id: org_id});
+
         return {
           uuid,
         };
@@ -144,6 +150,8 @@ const labelResolvers = {
         }      
 
         await models.Label.deleteOne({ org_id: org_id, uuid:label.uuid });
+
+        pubSub.channelSubChangedFunc({org_id: org_id});
   
         return {
           uuid: label.uuid,
@@ -178,6 +186,8 @@ const labelResolvers = {
         }      
 
         await models.Label.deleteOne({ org_id: org_id, uuid:label.uuid });
+
+        pubSub.channelSubChangedFunc({org_id: org_id});
   
         return {
           uuid: label.uuid,
@@ -209,6 +219,7 @@ const labelResolvers = {
           {$push: {tags: {uuid: label.uuid, name: label.name}}});
 
         logger.debug({ req_id, user: whoIs(me), uuid, clusters, res }, `${queryName} exit`);
+        pubSub.channelSubChangedFunc({org_id: org_id});
         return {modified: res.modifiedCount !== undefined ? res.modifiedCount : res.nModified };
   
       } catch(err){
@@ -237,6 +248,7 @@ const labelResolvers = {
           {$pull: {tags: {uuid}}});
 
         logger.debug({ req_id, user: whoIs(me), uuid, clusters, res }, `${queryName} exit`);
+        pubSub.channelSubChangedFunc({org_id: org_id});
         return {modified: res.modifiedCount !== undefined ? res.modifiedCount : res.nModified };
   
       } catch(err){

--- a/app/apollo/resolvers/label.js
+++ b/app/apollo/resolvers/label.js
@@ -30,7 +30,7 @@ const labelResolvers = {
       await validAuth(me, orgId, ACTIONS.READ, TYPES.LABEL, queryName, context);
       var labels;
       try{
-        labels = await models.Label.find({ orgId }).lean();
+        labels = await models.Label.find({ org_id: orgId }).lean();
         var ownerIds = _.map(labels, 'owner');
         var owners = await models.User.getBasicUsersByIds(ownerIds);
   
@@ -51,7 +51,7 @@ const labelResolvers = {
       await validAuth(me, orgId, ACTIONS.READ, TYPES.LABEL, queryName, context);
   
       try{
-        var label = await models.Label.findOne({ orgId, uuid }).lean();
+        var label = await models.Label.findOne({ org_id: orgId, uuid }).lean();
         if (!label) {
           throw new NotFoundError(`could not find label with uuid ${uuid}.`);
         }
@@ -75,7 +75,7 @@ const labelResolvers = {
       await validAuth(me, orgId, ACTIONS.READ, TYPES.LABEL, queryName, context);
   
       try{
-        var label = await models.Label.findOne({ orgId, name }).lean();
+        var label = await models.Label.findOne({ org_id: orgId, name }).lean();
         if (!label) {
           throw new NotFoundError(`could not find label with name ${name}.`);
         }
@@ -102,14 +102,14 @@ const labelResolvers = {
     
       try {
         // might not necessary with unique index. Worth to check to return error better.
-        const label = await models.Label.findOne({ orgId, name });
+        const label = await models.Label.findOne({ org_id: orgId, name });
         if(label){
           throw new ValidationError(`The label name ${name} already exists.`);
         }
         const uuid = UUID();
         await models.Label.create({
           _id: UUID(),
-          uuid, orgId, name, owner: me._id,
+          uuid, org_id: orgId, name, owner: me._id,
         });
         return {
           uuid,
@@ -127,7 +127,7 @@ const labelResolvers = {
       await validAuth(me, orgId, ACTIONS.MANAGE, TYPES.LABEL, queryName, context);
   
       try{
-        const label = await models.Label.findOne({ uuid, orgId }).lean();
+        const label = await models.Label.findOne({ uuid, org_id: orgId }).lean();
         if(!label){
           throw new NotFoundError(`label uuid "${uuid}" not found`);
         }
@@ -143,7 +143,7 @@ const labelResolvers = {
           throw new ValidationError(`${clusterCount} clusters depend on this label. Please update/remove the label from the clusters.`);
         }      
 
-        await models.Label.deleteOne({ orgId, uuid:label.uuid });
+        await models.Label.deleteOne({ org_id: orgId, uuid:label.uuid });
   
         return {
           uuid: label.uuid,
@@ -162,7 +162,7 @@ const labelResolvers = {
       await validAuth(me, orgId, ACTIONS.MANAGE, TYPES.LABEL, queryName, context);
   
       try{
-        const label = await models.Label.findOne({ name, orgId }).lean();
+        const label = await models.Label.findOne({ name, org_id: orgId }).lean();
         if(!label){
           throw new NotFoundError(`label name "${name}" not found`);
         }
@@ -177,7 +177,7 @@ const labelResolvers = {
           throw new ValidationError(`${clusterCount} clusters depend on this label. Please update/remove the label from the clusters.`);
         }      
 
-        await models.Label.deleteOne({ orgId, uuid:label.uuid });
+        await models.Label.deleteOne({ org_id: orgId, uuid:label.uuid });
   
         return {
           uuid: label.uuid,
@@ -198,7 +198,7 @@ const labelResolvers = {
       try{
 
         // validate the label exits in the db first.
-        const label = await models.Label.findOne({ orgId, uuid });
+        const label = await models.Label.findOne({ org_id: orgId, uuid });
         if(!label){
           throw new NotFoundError(`label uuid "${uuid}" not found`);
         }
@@ -226,7 +226,7 @@ const labelResolvers = {
       try{
 
         // validate the label exits in the db first.
-        const label = await models.Label.findOne({ orgId, uuid });
+        const label = await models.Label.findOne({ org_id: orgId, uuid });
         if(!label){
           throw new NotFoundError(`label uuid "${uuid}" not found`);
         }

--- a/app/apollo/resolvers/label.js
+++ b/app/apollo/resolvers/label.js
@@ -23,14 +23,14 @@ const { whoIs, validAuth, NotFoundError } = require ('./common');
 
 const labelResolvers = {
   Query: {
-    labels: async(parent, { orgId }, context) => {
+    labels: async(parent, { org_id }, context) => {
       const { models, me, req_id, logger } = context;
       const queryName = 'labels';
-      logger.debug({req_id, user: whoIs(me), orgId }, `${queryName} enter`);
-      await validAuth(me, orgId, ACTIONS.READ, TYPES.LABEL, queryName, context);
+      logger.debug({req_id, user: whoIs(me), org_id }, `${queryName} enter`);
+      await validAuth(me, org_id, ACTIONS.READ, TYPES.LABEL, queryName, context);
       var labels;
       try{
-        labels = await models.Label.find({ org_id: orgId }).lean();
+        labels = await models.Label.find({ org_id: org_id }).lean();
         var ownerIds = _.map(labels, 'owner');
         var owners = await models.User.getBasicUsersByIds(ownerIds);
   
@@ -44,22 +44,22 @@ const labelResolvers = {
       }
       return labels;
     },
-    label: async(parent, { orgId, uuid }, context) => {
+    label: async(parent, { org_id: org_id, uuid }, context) => {
       const { models, me, req_id, logger } = context;
       const queryName = 'label';
-      logger.debug({req_id, user: whoIs(me), orgId, uuid}, `${queryName} enter`);
-      await validAuth(me, orgId, ACTIONS.READ, TYPES.LABEL, queryName, context);
+      logger.debug({req_id, user: whoIs(me), org_id, uuid}, `${queryName} enter`);
+      await validAuth(me, org_id, ACTIONS.READ, TYPES.LABEL, queryName, context);
   
       try{
-        var label = await models.Label.findOne({ org_id: orgId, uuid }).lean();
+        var label = await models.Label.findOne({ org_id: org_id, uuid }).lean();
         if (!label) {
           throw new NotFoundError(`could not find label with uuid ${uuid}.`);
         }
         var owners = await models.User.getBasicUsersByIds([label.owner]);
 
-        const subscriptionCount = await models.Subscription.count({ org_id: orgId, tags: label.name });
+        const subscriptionCount = await models.Subscription.count({ org_id: org_id, tags: label.name });
 
-        const clusterCount = await models.Cluster.count({ org_id: orgId, 'tags.uuid': label.uuid });
+        const clusterCount = await models.Cluster.count({ org_id: org_id, 'tags.uuid': label.uuid });
 
         label.owner = owners[label.owner];
         return {clusterCount, subscriptionCount, ...label};
@@ -68,22 +68,22 @@ const labelResolvers = {
         throw err;
       }
     },
-    labelByName: async(parent, { orgId, name }, context) => {
+    labelByName: async(parent, { org_id, name }, context) => {
       const { models, me, req_id, logger } = context;
       const queryName = 'labelByName';
-      logger.debug({req_id, user: whoIs(me), orgId, name}, `${queryName} enter`);
-      await validAuth(me, orgId, ACTIONS.READ, TYPES.LABEL, queryName, context);
+      logger.debug({req_id, user: whoIs(me), org_id, name}, `${queryName} enter`);
+      await validAuth(me, org_id, ACTIONS.READ, TYPES.LABEL, queryName, context);
   
       try{
-        var label = await models.Label.findOne({ org_id: orgId, name }).lean();
+        var label = await models.Label.findOne({ org_id: org_id, name }).lean();
         if (!label) {
           throw new NotFoundError(`could not find label with name ${name}.`);
         }
         var owners = await models.User.getBasicUsersByIds([label.owner]);
 
-        const subscriptionCount = await models.Subscription.count({ org_id: orgId, tags: label.name });
+        const subscriptionCount = await models.Subscription.count({ org_id: org_id, tags: label.name });
 
-        const clusterCount = await models.Cluster.count({ org_id: orgId, 'tags.uuid': label.uuid });
+        const clusterCount = await models.Cluster.count({ org_id: org_id, 'tags.uuid': label.uuid });
 
         label.owner = owners[label.owner];
         return {clusterCount, subscriptionCount, ...label};
@@ -94,22 +94,22 @@ const labelResolvers = {
     },    
   },
   Mutation: {
-    addLabel: async (parent, { orgId, name }, context)=>{
+    addLabel: async (parent, { org_id, name }, context)=>{
       const { models, me, req_id, logger } = context;
       const queryName = 'addLabel';
-      logger.debug({ req_id, user: whoIs(me), orgId, name }, `${queryName} enter`);
-      await validAuth(me, orgId, ACTIONS.MANAGE, TYPES.LABEL, queryName, context);
+      logger.debug({ req_id, user: whoIs(me), org_id, name }, `${queryName} enter`);
+      await validAuth(me, org_id, ACTIONS.MANAGE, TYPES.LABEL, queryName, context);
     
       try {
         // might not necessary with unique index. Worth to check to return error better.
-        const label = await models.Label.findOne({ org_id: orgId, name });
+        const label = await models.Label.findOne({ org_id: org_id, name });
         if(label){
           throw new ValidationError(`The label name ${name} already exists.`);
         }
         const uuid = UUID();
         await models.Label.create({
           _id: UUID(),
-          uuid, org_id: orgId, name, owner: me._id,
+          uuid, org_id: org_id, name, owner: me._id,
         });
         return {
           uuid,
@@ -120,30 +120,30 @@ const labelResolvers = {
       }
     },
 
-    removeLabel: async (parent, { orgId, uuid }, context)=>{
+    removeLabel: async (parent, { org_id, uuid }, context)=>{
       const { models, me, req_id, logger } = context;
       const queryName = 'removeLabel';
-      logger.debug({ req_id, user: whoIs(me), orgId, uuid }, `${queryName} enter`);
-      await validAuth(me, orgId, ACTIONS.MANAGE, TYPES.LABEL, queryName, context);
+      logger.debug({ req_id, user: whoIs(me), org_id, uuid }, `${queryName} enter`);
+      await validAuth(me, org_id, ACTIONS.MANAGE, TYPES.LABEL, queryName, context);
   
       try{
-        const label = await models.Label.findOne({ uuid, org_id: orgId }).lean();
+        const label = await models.Label.findOne({ uuid, org_id: org_id }).lean();
         if(!label){
           throw new NotFoundError(`label uuid "${uuid}" not found`);
         }
   
-        const subCount = await models.Subscription.count({ org_id: orgId, tags: label.name });
+        const subCount = await models.Subscription.count({ org_id: org_id, tags: label.name });
   
         if(subCount > 0){
           throw new ValidationError(`${subCount} subscriptions depend on this label. Please update/remove them before removing this label.`);
         }
         
-        const clusterCount = await models.Cluster.count({ org_id: orgId, 'tags.uuid': label.uuid });
+        const clusterCount = await models.Cluster.count({ org_id: org_id, 'tags.uuid': label.uuid });
         if(clusterCount > 0){
           throw new ValidationError(`${clusterCount} clusters depend on this label. Please update/remove the label from the clusters.`);
         }      
 
-        await models.Label.deleteOne({ org_id: orgId, uuid:label.uuid });
+        await models.Label.deleteOne({ org_id: org_id, uuid:label.uuid });
   
         return {
           uuid: label.uuid,
@@ -155,29 +155,29 @@ const labelResolvers = {
       }
     },
 
-    removeLabelByName: async (parent, { orgId, name }, context)=>{
+    removeLabelByName: async (parent, { org_id, name }, context)=>{
       const { models, me, req_id, logger } = context;
       const queryName = 'removeLabel';
-      logger.debug({ req_id, user: whoIs(me), orgId, name }, `${queryName} enter`);
-      await validAuth(me, orgId, ACTIONS.MANAGE, TYPES.LABEL, queryName, context);
+      logger.debug({ req_id, user: whoIs(me), org_id, name }, `${queryName} enter`);
+      await validAuth(me, org_id, ACTIONS.MANAGE, TYPES.LABEL, queryName, context);
   
       try{
-        const label = await models.Label.findOne({ name, org_id: orgId }).lean();
+        const label = await models.Label.findOne({ name, org_id: org_id }).lean();
         if(!label){
           throw new NotFoundError(`label name "${name}" not found`);
         }
   
-        const subCount = await models.Subscription.count({ org_id: orgId, tags: label.name });
+        const subCount = await models.Subscription.count({ org_id: org_id, tags: label.name });
         if(subCount > 0){
           throw new ValidationError(`${subCount} subscriptions depend on this label. Please update/remove them before removing this label.`);
         }
         
-        const clusterCount = await models.Cluster.count({ org_id: orgId, 'tags.uuid': label.uuid });
+        const clusterCount = await models.Cluster.count({ org_id: org_id, 'tags.uuid': label.uuid });
         if(clusterCount > 0){
           throw new ValidationError(`${clusterCount} clusters depend on this label. Please update/remove the label from the clusters.`);
         }      
 
-        await models.Label.deleteOne({ org_id: orgId, uuid:label.uuid });
+        await models.Label.deleteOne({ org_id: org_id, uuid:label.uuid });
   
         return {
           uuid: label.uuid,
@@ -189,23 +189,23 @@ const labelResolvers = {
       }
     },
 
-    labelClusters: async (parent, { orgId, uuid, clusters }, context)=>{
+    labelClusters: async (parent, { org_id, uuid, clusters }, context)=>{
       const { models, me, req_id, logger } = context;
       const queryName = 'labelClusters';
       logger.debug({ req_id, user: whoIs(me), uuid, clusters }, `${queryName} enter`);
-      await validAuth(me, orgId, ACTIONS.MANAGE, TYPES.LABEL, queryName, context);
+      await validAuth(me, org_id, ACTIONS.MANAGE, TYPES.LABEL, queryName, context);
 
       try{
 
         // validate the label exits in the db first.
-        const label = await models.Label.findOne({ org_id: orgId, uuid });
+        const label = await models.Label.findOne({ org_id: org_id, uuid });
         if(!label){
           throw new NotFoundError(`label uuid "${uuid}" not found`);
         }
 
         // update clusters label array with the above label
         const res = await models.Cluster.updateMany(
-          {org_id: orgId, cluster_id: {$in: clusters}, 'tags.uuid': {$nin: [uuid]}}, 
+          {org_id: org_id, cluster_id: {$in: clusters}, 'tags.uuid': {$nin: [uuid]}}, 
           {$push: {tags: {uuid: label.uuid, name: label.name}}});
 
         logger.debug({ req_id, user: whoIs(me), uuid, clusters, res }, `${queryName} exit`);
@@ -217,23 +217,23 @@ const labelResolvers = {
       }
     },
 
-    unlabelClusters: async (parent, { orgId, uuid, clusters }, context)=>{
+    unlabelClusters: async (parent, { org_id, uuid, clusters }, context)=>{
       const { models, me, req_id, logger } = context;
       const queryName = 'unlabelClusters';
       logger.debug({ req_id, user: whoIs(me), uuid, clusters }, `${queryName} enter`);
-      await validAuth(me, orgId, ACTIONS.MANAGE, TYPES.LABEL, queryName, context);
+      await validAuth(me, org_id, ACTIONS.MANAGE, TYPES.LABEL, queryName, context);
 
       try{
 
         // validate the label exits in the db first.
-        const label = await models.Label.findOne({ org_id: orgId, uuid });
+        const label = await models.Label.findOne({ org_id: org_id, uuid });
         if(!label){
           throw new NotFoundError(`label uuid "${uuid}" not found`);
         }
 
         // update clusters label array with the above label
         const res = await models.Cluster.updateMany(
-          {org_id: orgId, cluster_id: {$in: clusters}, 'tags.uuid': {$in: [uuid]}}, 
+          {org_id: org_id, cluster_id: {$in: clusters}, 'tags.uuid': {$in: [uuid]}}, 
           {$pull: {tags: {uuid}}});
 
         logger.debug({ req_id, user: whoIs(me), uuid, clusters, res }, `${queryName} exit`);

--- a/app/apollo/resolvers/subscription.js
+++ b/app/apollo/resolvers/subscription.js
@@ -29,7 +29,7 @@ const pubSub = GraphqlPubSub.getInstance();
 async function validateTags(org_id, tags, context) {
   const { req_id, me, models, logger } = context;
   // validate tags are all exists in label dbs
-  var labelCount = await models.Label.count({orgId: org_id, name: {$in: tags} });
+  var labelCount = await models.Label.count({org_id: org_id, name: {$in: tags} });
   if (labelCount < tags.length) {
     if (process.env.LABEL_VALIDATION_REQUIRED) {
       throw new ValidationError(`could not find all the tags ${tags} in the label database, please create them first.`);
@@ -37,7 +37,7 @@ async function validateTags(org_id, tags, context) {
       // in migration period, we automatically populate tags into label db
       logger.info({req_id, user: whoIs(me), org_id}, `could not find all the tags ${tags}, migrate them into label database.`);
       await models.Label.findOrCreateList(models, org_id, tags, context);
-      labelCount = await models.Label.count({orgId: org_id, name: {$in: tags} });
+      labelCount = await models.Label.count({org_id: org_id, name: {$in: tags} });
     }
   }
   logger.debug({req_id, user: whoIs(me), tags, org_id, labelCount}, 'validateTags');

--- a/app/apollo/resolvers/subscription.js
+++ b/app/apollo/resolvers/subscription.js
@@ -107,8 +107,8 @@ const subscriptionResolvers = {
         throw new ValidationError(`could not locate the cluster with cluster_id ${cluster_id}`);
       }
       var userTags = [];
-      if (cluster.labels) {
-        userTags = cluster.labels.map(l => l.name);
+      if (cluster.tags) {
+        userTags = cluster.tags.map(l => l.name);
       }
       logger.debug({user: 'graphql api user', org_id, userTags }, `${query} enter`);
       let urls = [];

--- a/app/apollo/resolvers/subscription.js
+++ b/app/apollo/resolvers/subscription.js
@@ -114,7 +114,7 @@ const subscriptionResolvers = {
       logger.debug({user: 'graphql api user', org_id, userTags }, `${query} enter`);
       let urls = [];
       try {
-        // Return subscriptions where userTags pass in from the query must be a subset of $tags stored in mongo 
+        // Return subscriptions that contain any userTags passed in from the query 
         // examples:
         //   mongo tags: ['dev', 'prod'] , userTags: ['dev'] ==> true
         //   mongo tags: ['dev', 'prod'] , userTags: ['dev', 'prod'] ==> true

--- a/app/apollo/schema/label.js
+++ b/app/apollo/schema/label.js
@@ -4,7 +4,7 @@ const labelSchema = gql`
   
   type Label {
     uuid: String!
-    orgId: String!
+    org_id: String!
     name: String!
     owner: BasicUser!
     created: Date!
@@ -12,7 +12,7 @@ const labelSchema = gql`
 
   type LabelDetail {
     uuid: String!
-    orgId: String!
+    org_id: String!
     name: String!
     owner: BasicUser!
     created: Date!
@@ -39,46 +39,46 @@ const labelSchema = gql`
 
   extend type Query {
     """
-    list all labels for orgId
+    list all labels for org_id
     """
-    labels(orgId: String!): [Label]
+    labels(org_id: String!): [Label]
 
     """
-    Gets a label detail for orgId and uuid
+    Gets a label detail for org_id and uuid
     """
-    label(orgId: String! uuid: String!): LabelDetail
+    label(org_id: String! uuid: String!): LabelDetail
 
     """
-    Gets a label detail for orgId and name
+    Gets a label detail for org_id and name
     """
-    labelByName(orgId: String! name: String!): LabelDetail
+    labelByName(org_id: String! name: String!): LabelDetail
   }
 
   extend type Mutation {
     """
     Adds a label
     """
-    addLabel(orgId: String! name: String!): AddLabelReply!
+    addLabel(org_id: String! name: String!): AddLabelReply!
 
     """
     Removes a label 
     """
-    removeLabel(orgId: String! uuid: String!): RemoveLabelReply!
+    removeLabel(org_id: String! uuid: String!): RemoveLabelReply!
 
     """
     Removes a label by name 
     """
-    removeLabelByName(orgId: String! name: String!): RemoveLabelReply!
+    removeLabelByName(org_id: String! name: String!): RemoveLabelReply!
 
     """
     label a list of clusters
     """
-    labelClusters(orgId: String! uuid: String! clusters: [String]!): LabelClustersReply!
+    labelClusters(org_id: String! uuid: String! clusters: [String]!): LabelClustersReply!
 
     """
     unlabel a list of clusters
     """
-    unlabelClusters(orgId: String! uuid: String! clusters: [String]!): UnlabelClustersReply!
+    unlabelClusters(org_id: String! uuid: String! clusters: [String]!): UnlabelClustersReply!
 
   }
 `;

--- a/app/apollo/test/label.spec.js
+++ b/app/apollo/test/label.spec.js
@@ -280,7 +280,7 @@ describe('label graphql test suite', () => {
           data: { labels },
         },
       } = await labelApi.labels(token, {
-        orgId: org01._id,
+        org_id: org01._id,
       });
 
       console.log(`get all labels by Org ID: labels = ${JSON.stringify(labels)}`);

--- a/app/apollo/test/label.spec.js
+++ b/app/apollo/test/label.spec.js
@@ -126,21 +126,21 @@ const createLabels = async () => {
   await models.Label.create({
     _id: UUID(),
     uuid: UUID(),
-    orgId: org01._id,
+    org_id: org01._id,
     name: 'label1',
     owner: 'undefined'
   });
   await models.Label.create({
     _id: UUID(),
     uuid: UUID(),
-    orgId: org01._id,
+    org_id: org01._id,
     name: 'label2',
     owner: 'undefined'
   });
   await models.Label.create({
     _id: UUID(),
     uuid: UUID(),
-    orgId: org77._id,
+    org_id: org77._id,
     name: 'label1',
     owner: 'undefined'
   });

--- a/app/apollo/test/labelApi.js
+++ b/app/apollo/test/labelApi.js
@@ -22,10 +22,10 @@ const labelFunc = grahqlUrl => {
       grahqlUrl,
       {
         query: `
-          query($orgId: String!) {
-            labels( orgId: $orgId ) {
+          query($org_id: String!) {
+            labels( org_id: $org_id ) {
                 uuid
-                orgId
+                org_id
                 name
                 owner {
                   _id
@@ -50,4 +50,3 @@ const labelFunc = grahqlUrl => {
 };
         
 module.exports = labelFunc;
-

--- a/app/apollo/test/subscriptions.spec.js
+++ b/app/apollo/test/subscriptions.spec.js
@@ -194,14 +194,14 @@ const createChannels = async () => {
 const createLabels = async () => {
   await models.Label.create({
     _id: UUID(),
-    orgId: org01._id,
+    org_id: org01._id,
     uuid: UUID(),
     name: 'dev',
     owner: user01._id,
   });
   await models.Label.create({
     _id: UUID(),
-    orgId: org77._id,
+    org_id: org77._id,
     uuid: UUID(),
     name: 'dev',
     owner: user01._id,

--- a/app/conf.js
+++ b/app/conf.js
@@ -25,7 +25,8 @@ const conf = {
     accessKeyId: process.env.S3_ACCESS_KEY_ID,
     secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
     locationConstraint: process.env.S3_LOCATION_CONSTRAINT || 'us-standard',
-    bucketPrefix: process.env.S3_BUCKET_PREFIX || 'razee',
+    channelBucket: process.env.S3_CHANNEL_BUCKET || 'razee',
+    resourceBucket: process.env.S3_RESOURCE_BUCKET || process.env.S3_CHANNEL_BUCKET || 'razee',
     s3ForcePathStyle: true,
     signatureVersion: 'v4',
     sslEnabled: !process.env.S3_DISABLE_SSL, //for local minio support

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -148,7 +148,7 @@ async function initialize(){
       ],
       labels: [
         {
-          keys: { orgId: 1, name: 1 },
+          keys: { org_id: 1, name: 1 },
           options: { name: 'orgId.name', unique: true }
         }
       ],

--- a/app/routes/v2/clusters.js
+++ b/app/routes/v2/clusters.js
@@ -38,8 +38,8 @@ const buildPushObj = require('../../utils/cluster.js').buildPushObj;
 const buildHashForResource = require('../../utils/cluster.js').buildHashForResource;
 const { CLUSTER_LIMITS, CLUSTER_REG_STATES } = require('../../apollo/models/const');
 const { GraphqlPubSub } = require('../../apollo/subscription');
-
 const pubSub = GraphqlPubSub.getInstance();
+const conf = require('../../conf.js').conf;
 
 const addUpdateCluster = async (req, res, next) => {
   try {
@@ -127,8 +127,7 @@ var runAddClusterWebhook = async(req, orgId, clusterId, clusterName)=>{
 
 const pushToS3 = async (req, key, dataStr) => {
   //if its a new or changed resource, write the data out to an S3 object
-  const orgId = key.org_id.toLowerCase(); 
-  const bucket = `razee-${orgId}`;
+  const bucket = conf.s3.resourceBucket;
   const hash = crypto.createHash('sha256');
   const hashKey = hash.update(JSON.stringify(key)).digest('hex');
   await req.s3.createBucketAndObject(bucket, hashKey, dataStr);

--- a/app/s3/s3Client.tests.js
+++ b/app/s3/s3Client.tests.js
@@ -37,7 +37,7 @@ describe('s3', () => {
           accessKeyId: 'accessKey',
           secretAccessKey: 'secretKey',
           locationConstraint: 'us-standard',
-          bucketPrefix: 'razee',
+          channelBucket: 'razee',
           s3ForcePathStyle: true,
           signatureVersion: 'v4',
           sslEnabled: false,

--- a/app/utils/subscriptions.js
+++ b/app/utils/subscriptions.js
@@ -19,14 +19,7 @@ const tagsStrToArr = (str)=>{
   return tags;
 };
 
-const getSubscriptionUrls = async(orgId, tags, subsForOrg) => {
-  // get tags.  query subscriptions that match all tags
-  const matchingSubscriptions = _.filter(subsForOrg, (subscription)=>{
-    var groupTags = tagsStrToArr(subscription.tags);
-    return _.every(groupTags, (requiredTag)=>{
-      return _.includes(tags, requiredTag);
-    });
-  });
+const getSubscriptionUrls = async(orgId, tags, matchingSubscriptions) => {
 
   const matchingChannels = await models.Channel.find({
     org_id: orgId,

--- a/kubernetes/razeedash-api/resource.yaml
+++ b/kubernetes/razeedash-api/resource.yaml
@@ -77,11 +77,17 @@ items:
                   name: razeedash-secret
                   key: s3_secret_access_key
                   optional: true
-            - name: S3_BUCKET_PREFIX
+            - name: S3_CHANNEL_BUCKET
               valueFrom:
                 configMapKeyRef:
                   name: razeedash-config
-                  key: s3_bucket_prefix
+                  key: s3_channel_bucket
+                  optional: true
+            - name: S3_RESOURCE_BUCKET
+              valueFrom:
+                configMapKeyRef:
+                  name: razeedash-config
+                  key: s3_resource_bucket
                   optional: true
             - name: MONGO_URL
               valueFrom:


### PR DESCRIPTION
- use a single s3 bucket
- match all clusters with any tags in a subscription instead of all tag

  // Return subscriptions where $tags stored in mongo are a subset of the userTags passed in from the query
        // examples:
        //   mongo tags: ['dev', 'prod'] , userTags: ['dev'] ==> false
        //   mongo tags: ['dev', 'prod'] , userTags: ['dev', 'prod'] ==> true
        //   mongo tags: ['dev', 'prod'] , userTags: ['dev', 'prod', 'stage'] ==> true
        //   mongo tags: ['dev', 'prod'] , userTags: ['stage'] ==> false