### PR TITLE
Improvement: allow registration url returned in clusterByClusterID response

### DIFF
--- a/app/apollo/resolvers/cluster.js
+++ b/app/apollo/resolvers/cluster.js
@@ -83,6 +83,15 @@ const clusterResolvers = {
         ...conditions
       }).lean();
 
+      var { url } = await models.Organization.getRegistrationUrl(orgId, context);
+      url = url + `&clusterId=${clusterId}`;
+      if (RDD_STATIC_ARGS.length > 0) {
+        RDD_STATIC_ARGS.forEach(arg => {
+          url += `&args=${arg}`;
+        });
+      }
+      if (!result.registration) result.registration = {};
+      result.registration.url = url;
       return result;
     }, // end cluster by _id
 


### PR DESCRIPTION
Allow registration url returned in clusterByClusterID response as registration.url, so that a user does not capture the response from registerCluster call, he could still have a chance to get the url. 