### PR TITLE
Improvement: add ByName support for channel and channel version

### DIFF
--- a/app/apollo/schema/channel.js
+++ b/app/apollo/schema/channel.js
@@ -76,10 +76,26 @@ const channelSchema = gql`
      channel(orgId: String!, uuid: String! ): Channel
 
      """
-     Gets a yaml version from this channel
+     Gets a channel from the given orgId and channel name
+     """
+     channelByName(orgId: String!, name: String! ): Channel
+
+     """
+     deprecated, please use channelVersion api. Gets a channel version info from this channel uuid and version uuid
      """
      getChannelVersion(orgId: String!, channelUuid: String!, versionUuid: String!): DeployableVersion!
+
+     """
+     Gets a channel version info from this channel uuid and version uuid 
+     """
+     channelVersion(orgId: String!, channelUuid: String!, versionUuid: String!): DeployableVersion!
+
+     """
+     Gets a channel version info from this channel name and version name 
+     """
+     channelVersionByName(orgId: String!, channelName: String!, versionName: String!): DeployableVersion!
   }
+
   extend type Mutation {
      """
      Adds a channel

--- a/app/apollo/test/channel.spec.js
+++ b/app/apollo/test/channel.spec.js
@@ -227,6 +227,28 @@ describe('channel graphql test suite', () => {
     }
   });
 
+  it('get channel by channel name', async () => {
+    try {
+      const {
+        data: {
+          data: { channelByName },
+        },
+      } = await channelApi.channelByName(token, {
+        orgId: org01._id,
+        name: channel_01_name,
+      });
+    
+      expect(channelByName.uuid).to.equal(channel_01_uuid);
+    } catch (error) {
+      if (error.response) {
+        console.error('error encountered:  ', error.response.data);
+      } else {
+        console.error('error encountered:  ', error);
+      }
+      throw error;
+    }
+  });
+
   it('add a channel', async () => {
     try {
       const {
@@ -288,18 +310,35 @@ describe('channel graphql test suite', () => {
       // step 3: get a channel version by user1 token
       const {
         data: {
-          data: { getChannelVersion },
+          data: { channelVersion },
         },
-      } = await channelApi.getChannelVersion(token, {
+      } = await channelApi.channelVersion(token, {
         orgId: org01._id,
         channelUuid: channel_01_uuid,
         versionUuid: addChannelVersion.versionUuid,
       });      
 
-      expect(getChannelVersion.channelName).to.equal(channel_01_name);
-      expect(getChannelVersion.name).to.equal(`${channel_01_name}:v.0.1`);
-      expect(getChannelVersion.content).to.equal('{"n0": 123.45}');
-      expect(getChannelVersion.created).to.be.an('string');
+      expect(channelVersion.channelName).to.equal(channel_01_name);
+      expect(channelVersion.name).to.equal(`${channel_01_name}:v.0.1`);
+      expect(channelVersion.content).to.equal('{"n0": 123.45}');
+      expect(channelVersion.created).to.be.an('string');
+
+      // step 4: get a channel version by name by user1 token
+      const {
+        data: {
+          data: { channelVersionByName },
+        },
+      } = await channelApi.channelVersionByName(token, {
+        orgId: org01._id,
+        channelName: channel_01_name,
+        versionName: `${channel_01_name}:v.0.2`,
+      });      
+
+      expect(channelVersionByName.channelName).to.equal(channel_01_name);
+      expect(channelVersionByName.name).to.equal(`${channel_01_name}:v.0.2`);
+      expect(channelVersionByName.content).to.equal('{"n0": 456.78}');
+      expect(channelVersionByName.created).to.be.an('string');
+
     } catch (error) {
       if (error.response) {
         console.error('error encountered:  ', error.response.data);

--- a/app/apollo/test/channelApi.js
+++ b/app/apollo/test/channelApi.js
@@ -75,6 +75,35 @@ const channelFunc = grahqlUrl => {
       },
     );
 
+  const channelByName = async (token, variables) =>
+    axios.post(
+      grahqlUrl,
+      {
+        query: `
+          query($orgId: String! $name: String!) {
+            channelByName(orgId: $orgId name: $name) {
+              uuid
+              orgId
+              name
+              created
+              versions {
+                uuid
+                name
+                description
+                location
+              }
+          }
+        }
+    `,
+        variables,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
   const getChannelVersion = async (token, variables) =>
     axios.post(
       grahqlUrl,
@@ -103,6 +132,62 @@ const channelFunc = grahqlUrl => {
       },
     );
 
+  const channelVersion = async (token, variables) =>
+    axios.post(
+      grahqlUrl,
+      {
+        query: `
+          query($orgId: String! $channelUuid: String!, $versionUuid: String!) {
+            channelVersion(orgId: $orgId channelUuid: $channelUuid versionUuid: $versionUuid) {
+              orgId
+              uuid
+              channelId
+              channelName
+              name
+              type
+              description
+              content
+              created
+          }
+        }
+    `,
+        variables,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+  const channelVersionByName = async (token, variables) =>
+    axios.post(
+      grahqlUrl,
+      {
+        query: `
+          query($orgId: String! $channelName: String!, $versionName: String!) {
+            channelVersionByName(orgId: $orgId channelName: $channelName versionName: $versionName) {
+              orgId
+              uuid
+              channelId
+              channelName
+              name
+              type
+              description
+              content
+              created
+          }
+        }
+    `,
+        variables,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+  
   const addChannelVersion = async (token, variables) =>
     axios.post(
       grahqlUrl,
@@ -211,7 +296,10 @@ const channelFunc = grahqlUrl => {
   return {
     channels,
     channel,
-    getChannelVersion,
+    channelByName,
+    channelVersion,
+    channelVersionByName,    
+    getChannelVersion, // deprecated
     addChannelVersion,
     removeChannelVersion,
     addChannel,


### PR DESCRIPTION
For CLI, most of users uses channel , channel version names, instead of their uuid. It is not efficient for CLI to make 2 API calls, first a `channels` call to get all channels with uuid, then use uuid returned and matched to get detailed info.  it would be better that the API could accept them. Their names are unique in org or in channel. I add 2 new API `channelByName` and `channelVersionByName` with test cases.