### PR TITLE
Fix: update subscription channelName when channel name is updated

### DIFF
--- a/app/apollo/resolvers/channel.js
+++ b/app/apollo/resolvers/channel.js
@@ -147,6 +147,12 @@ const channelResolvers = {
 
         await models.Channel.updateOne({ org_id, uuid }, { $set: { name } });
 
+        // find any subscriptions for this channel and update channelName in those subs
+        await models.Subscription.updateMany(
+          { org_id: org_id, channel_uuid: uuid },
+          { $set: { channelName: name } }
+        );
+
         return {
           uuid,
           success: true,


### PR DESCRIPTION
The subscriptions collection contains `channelName` so when the channel name for the `channels` collection is renamed then the `subscriptions` collection also needs to be updated