### PR TITLE
Improvement: piggyback subscriptions for channel and channelByName APIs

### DIFF
--- a/app/apollo/resolvers/subscription.js
+++ b/app/apollo/resolvers/subscription.js
@@ -134,16 +134,19 @@ const subscriptionResolvers = {
         logger.error(err);
         throw err;
       }
-      const ownerIds = _.map(subscriptions, 'owner');
-      const owners = await models.User.getBasicUsersByIds(ownerIds);
+      // render owner information if users ask for
+      if(queryFields.owner && subscriptions) {
+        const ownerIds = _.map(subscriptions, 'owner');
+        const owners = await models.User.getBasicUsersByIds(ownerIds);
 
-      subscriptions = subscriptions.map((sub)=>{
-        if(_.isUndefined(sub.channelName)){
-          sub.channelName = sub.channel;
-        }
-        sub.owner = owners[sub.owner];
-        return sub;
-      });
+        subscriptions = subscriptions.map((sub)=>{
+          if(_.isUndefined(sub.channelName)){
+            sub.channelName = sub.channel;
+          }
+          sub.owner = owners[sub.owner];
+          return sub;
+        });
+      }
 
       await applyQueryFieldsToSubscriptions(subscriptions, queryFields, { }, models);
 

--- a/app/apollo/schema/channel.js
+++ b/app/apollo/schema/channel.js
@@ -31,6 +31,7 @@ const channelSchema = gql`
     name: String!
     created: Date!
     versions: [ChannelVersion]
+    subscriptions: [BasicChannelSubscription]
   }
   type AddChannelReply {
     uuid: String!

--- a/app/apollo/schema/subscription.js
+++ b/app/apollo/schema/subscription.js
@@ -90,11 +90,11 @@ const subscriptionSchema = gql`
      """
      Get a single subscription
      """
-     subscription(orgId: String! uuid: String!): ChannelSubscription
+     subscription(orgId: String!, uuid: String!): ChannelSubscription
      """
      Get a single subscription by name
      """
-     subscriptionByName(orgId: String! name: String!): ChannelSubscription
+     subscriptionByName(orgId: String!, name: String!): ChannelSubscription
      """
      Agent-facing API, deprecated. Gets all subscriptions for a cluster
      """

--- a/app/apollo/schema/subscription.js
+++ b/app/apollo/schema/subscription.js
@@ -21,6 +21,18 @@ const subscriptionSchema = gql`
     id: String!
     name: String!
   }
+  type BasicChannelSubscription {
+    uuid: String!
+    orgId: String!
+    name: String!
+    groups: [String!]
+    channelUuid: String!
+    channelName: String!
+    version: String!
+    versionUuid: String!
+    created: Date!
+    updated: Date!
+  }
   type ChannelSubscription {
     uuid: String!
     orgId: String!
@@ -78,17 +90,17 @@ const subscriptionSchema = gql`
      """
      Get a single subscription
      """
-     subscription(orgId: String!, uuid: String!): ChannelSubscription
+     subscription(orgId: String! uuid: String!): ChannelSubscription
      """
      Get a single subscription by name
      """
-     subscriptionByName(orgId: String!, name: String!): ChannelSubscription
+     subscriptionByName(orgId: String! name: String!): ChannelSubscription
      """
-     Gets all subscriptions for a cluster, invoked from cluster-subscription agent, deprecated, please use subscriptionsByClusterId
+     Agent-facing API, deprecated. Gets all subscriptions for a cluster
      """
      subscriptionsByCluster(cluster_id: String): [UpdatedSubscriptionDeprecated]
      """
-     Gets all subscriptions for a cluster, invoked from cluster-subscription agent
+     Agent-facing API. Gets all subscriptions for a cluster.
      """
      subscriptionsByClusterId(clusterId: String!): [UpdatedSubscription]
   }


### PR DESCRIPTION
To avoid invoking 2 APIs, this PR conditionally returns basic subscriptions info with the channel, if users ask for them in one API call. 