### PR TITLE
Bug: missing await and sub for some resource(s) apis

### DIFF
--- a/app/apollo/models/resource.schema.js
+++ b/app/apollo/models/resource.schema.js
@@ -15,10 +15,11 @@
  */
 
 const mongoose = require('mongoose');
+const ObjectId = require('mongoose').Types.ObjectId;
 
 const ResourceSchema = new mongoose.Schema({
   _id: {
-    type: String,
+    type: ObjectId,
     alias: 'id',
   },
   org_id: {

--- a/app/apollo/resolvers/group.js
+++ b/app/apollo/resolvers/group.js
@@ -28,16 +28,27 @@ const pubSub = GraphqlPubSub.getInstance();
 const applyQueryFieldsToGroups = async(groups, queryFields, { orgId }, models)=>{
   if(queryFields.owner){
     const owners = await models.User.getBasicUsersByIds(_.uniq(_.map(groups, 'owner')));
-    var ownersById = _.groupBy(owners, 'id');
     _.each(groups, (group)=>{
-      group.owner = ownersById[group.owner];
+      group.owner = owners[group.owner];
     });
   }
   if(queryFields.subscriptions || queryFields.subscriptionCount){
     var groupNames = _.uniq(_.map(groups, 'name'));
-    const subscriptions = await models.Subscription.find({ org_id: orgId, groups: { $in: groupNames } }).lean({ virtuals: true });
+    var subscriptions = await models.Subscription.find({ org_id: orgId, groups: { $in: groupNames } }).lean({ virtuals: true });
+    if(queryFields.subscriptions.owner && subscriptions) {
+      const ownerIds = _.map(subscriptions, 'owner');
+      const subOwners = await models.User.getBasicUsersByIds(ownerIds);
+      subscriptions = subscriptions.map((sub)=>{
+        sub.owner = subOwners[sub.owner];
+        return sub;
+      });
+    }
     const subscriptionsByGroupName = {};
     _.each(subscriptions, (sub)=>{
+      if(_.isUndefined(sub.channelName)){
+        sub.channelName = sub.channel;
+      }
+      delete sub.channel; // can not render channel, too deep
       _.each(sub.groups, (groupName)=>{
         subscriptionsByGroupName[groupName] = subscriptionsByGroupName[groupName] || [];
         subscriptionsByGroupName[groupName].push(sub);

--- a/app/apollo/resolvers/resource.js
+++ b/app/apollo/resolvers/resource.js
@@ -271,7 +271,9 @@ const resourceResolvers = {
         searchFilter = buildSearchForResources(searchFilter, filter);
       }
       logger.debug({req_id}, `searchFilter=${JSON.stringify(searchFilter)}`);
-      return commonResourcesSearch({ context, org_id, searchFilter, limit, queryFields });
+      const resourcesResult = commonResourcesSearch({ context, org_id, searchFilter, limit, queryFields });
+      await applyQueryFieldsToResources(resourcesResult.resources, queryFields, { }, models);
+      return resourcesResult;
     },
 
     resource: async (parent, { orgId: org_id, id: _id, histId }, context, fullQuery) => {
@@ -341,7 +343,9 @@ const resourceResolvers = {
         });
       }
       const searchFilter = { org_id, 'searchableData.subscription_id': subscription_id };
-      return commonResourcesSearch({ context, org_id, searchFilter, queryFields });
+      const resourcesResult = commonResourcesSearch({ context, org_id, searchFilter, queryFields });
+      await applyQueryFieldsToResources(resourcesResult.resources, queryFields, { }, models);
+      return resourcesResult;
     },
 
     resourceHistory: async(parent, { orgId: org_id, clusterId: cluster_id, resourceSelfLink, beforeDate, afterDate, limit }, context)=>{

--- a/app/apollo/resolvers/resource.js
+++ b/app/apollo/resolvers/resource.js
@@ -246,7 +246,7 @@ const resourceResolvers = {
 
       await validAuth(me, org_id, ACTIONS.READ, TYPES.RESOURCE, queryName, context);
 
-      const cluster = models.Cluster.findOne({cluster_id}).lean();
+      const cluster = await models.Cluster.findOne({cluster_id}).lean({ virtuals: true });
       if (!cluster) {
         // if some tag of the sub does not in user's tag list, throws an error
         throw new NotFoundError(`Could not find the cluster for the cluster id ${cluster_id}.`);
@@ -325,7 +325,7 @@ const resourceResolvers = {
       logger.debug( {req_id, user: whoIs(me), org_id, subscription_id, queryFields}, `${queryName} enter`);
   
       await validAuth(me, org_id, ACTIONS.READ, TYPES.RESOURCE, queryName, context);
-      const subscription = models.Subscription.findOne({uuid: subscription_id}).lean();
+      const subscription = await models.Subscription.findOne({uuid: subscription_id}).lean({ virtuals: true });
       if (!subscription) {
         // if some tag of the sub does not in user's tag list, throws an error
         throw new NotFoundError(`Could not find the subscription for the subscription id ${subscription_id}.`);

--- a/app/apollo/resolvers/resource.js
+++ b/app/apollo/resolvers/resource.js
@@ -102,6 +102,7 @@ const commonResourceSearch = async ({ context, org_id, searchFilter, queryFields
     const conditions = await getGroupConditionsIncludingEmpty(me, org_id, ACTIONS.READ, 'uuid', 'resource.commonResourceSearch', context);
 
     let resource = await models.Resource.findOne(searchFilter).lean({ virtuals: true });
+
     if (!resource) return resource;
 
     if (queryFields['data'] && resource.data && isLink(resource.data) && s3IsDefined()) {

--- a/app/apollo/resolvers/resource.js
+++ b/app/apollo/resolvers/resource.js
@@ -102,7 +102,6 @@ const commonResourceSearch = async ({ context, org_id, searchFilter, queryFields
     const conditions = await getGroupConditionsIncludingEmpty(me, org_id, ACTIONS.READ, 'uuid', 'resource.commonResourceSearch', context);
 
     let resource = await models.Resource.findOne(searchFilter).lean({ virtuals: true });
-
     if (!resource) return resource;
 
     if (queryFields['data'] && resource.data && isLink(resource.data) && s3IsDefined()) {

--- a/app/apollo/resolvers/resource.js
+++ b/app/apollo/resolvers/resource.js
@@ -119,6 +119,10 @@ const commonResourceSearch = async ({ context, org_id, searchFilter, queryFields
       cluster.name = cluster.name || (cluster.metadata||{}).name ||  (cluster.registration||{}).name  || cluster.cluster_id;
       resource.cluster = cluster;
     }
+    if(queryFields['subscription'] && resource.searchableData && resource.searchableData.subscription_id) {
+      var subscriptions = await models.Subscription.findOne({ uuid: resource.searchableData.subscription_id}).lean({ virtuals: true });
+      resource.subscription = subscriptions;
+    }
 
     return resource;
   } catch (error) {

--- a/app/apollo/resolvers/resource.js
+++ b/app/apollo/resolvers/resource.js
@@ -271,7 +271,7 @@ const resourceResolvers = {
         searchFilter = buildSearchForResources(searchFilter, filter);
       }
       logger.debug({req_id}, `searchFilter=${JSON.stringify(searchFilter)}`);
-      const resourcesResult = commonResourcesSearch({ context, org_id, searchFilter, limit, queryFields });
+      const resourcesResult = await commonResourcesSearch({ context, org_id, searchFilter, limit, queryFields });
       await applyQueryFieldsToResources(resourcesResult.resources, queryFields, { }, models);
       return resourcesResult;
     },
@@ -316,7 +316,7 @@ const resourceResolvers = {
       await validAuth(me, org_id, ACTIONS.READ, TYPES.RESOURCE, queryName, context);
 
       const searchFilter = { org_id, cluster_id, selfLink };
-      return commonResourceSearch({ context, org_id, searchFilter, queryFields });
+      return await commonResourceSearch({ context, org_id, searchFilter, queryFields });
     },
 
     resourcesBySubscription: async ( parent, { orgId: org_id, subscriptionId: subscription_id}, context, fullQuery) => {
@@ -343,7 +343,7 @@ const resourceResolvers = {
         });
       }
       const searchFilter = { org_id, 'searchableData.subscription_id': subscription_id };
-      const resourcesResult = commonResourcesSearch({ context, org_id, searchFilter, queryFields });
+      const resourcesResult = await commonResourcesSearch({ context, org_id, searchFilter, queryFields });
       await applyQueryFieldsToResources(resourcesResult.resources, queryFields, { }, models);
       return resourcesResult;
     },

--- a/app/apollo/test/resource.spec.js
+++ b/app/apollo/test/resource.spec.js
@@ -155,6 +155,29 @@ const createClusters = async () => {
     },
   });
 };
+const createSubscriptions = async () => {
+  await models.Group.create({
+    _id: 'fake_g1_id',
+    org_id: org_01._id,
+    name: 'g1',
+    uuid: 'g1-uuid',
+  });
+  await models.Group.create({
+    _id: 'fake_g2_id',
+    org_id: org_01._id,
+    name: 'g2',
+    uuid: 'g2-uuid',
+  });
+  await models.Subscription.create({
+    _id: 'fake_sub_id',
+    org_id: org_01._id,
+    name: 'fake_abc-123-name',
+    uuid: 'abc-123',
+    groups: ['g1','g2'],
+    channel_uuid: 'fake-channel-uuid-123',
+    version_uuid: 'fake-version-uuid-123',
+  });
+};
 const createResources = async () => {
   await models.Resource.create({
     _id: new ObjectId('aaaabbbbcccc'),
@@ -282,6 +305,7 @@ describe('resource graphql test suite', () => {
     await createOrganizations();
     await createUsers();
     await createClusters();
+    await createSubscriptions();
     await createResources();
 
     await getPresetOrgs();


### PR DESCRIPTION
1. bug fix: missing await causes missing fields and lean is not working.

2. render subscriptions for resources if users ask for them.

3. fix `resource` API. Set `resource._id` type to `ObjectId` because it is populated by REST API as ObjectId type. which is caused by the change: https://github.com/razee-io/Razeedash-api/commit/d55006eb68b7256bde83f2f84027811d01102712#diff-2b03232d3d71f02aa4120c9e3d2c7befR21

4. quick fix groups api data.