### PR TITLE
Bug: missing deleted: false for some resource(s) APIs

### DIFF
--- a/app/apollo/resolvers/resource.js
+++ b/app/apollo/resolvers/resource.js
@@ -101,6 +101,7 @@ const commonResourceSearch = async ({ context, org_id, searchFilter, queryFields
   try {
     const conditions = await getGroupConditionsIncludingEmpty(me, org_id, ACTIONS.READ, 'uuid', 'resource.commonResourceSearch', context);
 
+    searchFilter['deleted'] = false;
     let resource = await models.Resource.findOne(searchFilter).lean({ virtuals: true });
 
     if (!resource) return resource;
@@ -358,7 +359,7 @@ const resourceResolvers = {
           return false;
         });
       }
-      const searchFilter = { org_id, 'searchableData.subscription_id': subscription_id };
+      const searchFilter = { org_id, 'searchableData.subscription_id': subscription_id, deleted: false, };
       const resourcesResult = await commonResourcesSearch({ context, org_id, searchFilter, queryFields });
       await applyQueryFieldsToResources(resourcesResult.resources, queryFields, { }, models);
       return resourcesResult;


### PR DESCRIPTION
missing `deleted: false` flag and causes exception when render clusterinfo for the deleted resource.