### PR TITLE
Bug: resource history entries point to the same s3 url

### DIFF
--- a/app/apollo/resolvers/resource.js
+++ b/app/apollo/resolvers/resource.js
@@ -77,7 +77,9 @@ const getS3Data = async (s3Link, logger) => {
     const link = url.parse(s3Link); 
     const paths = link.path.split('/');
     const bucket = paths[1];
-    const resourceName = decodeURI(paths[2]);
+    // we do not need to decode URL here because path[2] and path[3] are hash code
+    // path[2] stores keyHash , path[3] stores searchableDataHash 
+    const resourceName = paths.length > 3 ? paths[2] + '/' + paths[3] : paths[2];
     const s3stream = s3Client.getObject(bucket, resourceName).createReadStream();
     const yaml = await readS3File(s3stream);
     return yaml;


### PR DESCRIPTION
When S3 is enabled, all history entries' yamlStr point to the same S3 location. e.g. `https://s3.us-east.cloud-object-storage.appdomain.cloud/razee-stage-configs/f6839b5a1f49ab178d68603ac92eec7c55a8d1d07a49d4ea2329b592504962f8`. This is because the hashKey for the s3 path is only based on org_id, cluster_id, resourcesSelfLink and causes history always point to the same/latest s3 link.

<img width="1374" alt="Screen Shot 2020-07-22 at 10 17 15 PM" src="https://user-images.githubusercontent.com/42584020/88249084-4ccb8b00-cc71-11ea-9af0-08ed104954b0.png">

The PR is to add  `/${searchableDataHash}` at the end of the url: `https://${req.s3.endpoint}/${bucket}/${keyHash}/${searchableDataHash}` e.g. `https://s3.us-east.cloud-object-storage.appdomain.cloud/razee-stage-configs/f6839b5a1f49ab178d68603ac92eec7c55a8d1d07a49d4ea2329b592504962f8/3f971c4127fc74aabb2a922f8a6006182ea6ce6f`

The PR also fixes the resource query side API to handle additional `searchableDataHash` in the s3 path