### PR TITLE
New: do not log tokens in Production

### DIFF
--- a/app/apollo/utils/bunyan.js
+++ b/app/apollo/utils/bunyan.js
@@ -15,6 +15,11 @@
 */
 
 const responseCodeMapper = (status, err, meta) => {
+  if (process.env.NODE_ENV === 'production') {
+    if (meta['req-headers'] && meta['req-headers']['authorization']) {
+      meta['req-headers']['authorization'] = 'Bearer [HIDDEN]';
+    } 
+  }
   if (meta.method === 'OPTIONS' && status === 204) {
     // skip OPTION request 204 response
     return 'trace';


### PR DESCRIPTION
stop logging user tokens in Production - will keep logging in all other environments