### PR TITLE
New: added build time and build id endpoint so we can more easily see…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ script:
   - npm run test:apollo:default
   - npm run test:apollo:local
   - npm run test:apollo:passport.local
-  - docker build --rm -t "quay.io/razee/razeedash-api:${TRAVIS_COMMIT}" .
+  - export BUILD_TIME=`date '+%Y-%m-%d %H:%M:%S'`
+  - docker build --rm -t --build-arg BUILD_TIME="$BUILD_TIME" --build-arg BUILD_ID="${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT}" "quay.io/razee/razeedash-api:${TRAVIS_COMMIT}" .
   - if [ -n "${TRAVIS_TAG}" ]; then docker tag quay.io/razee/razeedash-api:${TRAVIS_COMMIT} quay.io/razee/razeedash-api:${TRAVIS_TAG}; fi
   - docker images
   - ./build/process-template.sh kubernetes/razeedash-api/resource.yaml >/tmp/resource.yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
   - npm run test:apollo:local
   - npm run test:apollo:passport.local
   - export BUILD_TIME=`date '+%Y-%m-%d %H:%M:%S'`
-  - docker build --rm -t --build-arg BUILD_TIME="$BUILD_TIME" --build-arg BUILD_ID="${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT}" "quay.io/razee/razeedash-api:${TRAVIS_COMMIT}" .
+  - docker build --rm --build-arg BUILD_TIME="$BUILD_TIME" --build-arg BUILD_ID="${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT}" -t "quay.io/razee/razeedash-api:${TRAVIS_COMMIT}" .
   - if [ -n "${TRAVIS_TAG}" ]; then docker tag quay.io/razee/razeedash-api:${TRAVIS_COMMIT} quay.io/razee/razeedash-api:${TRAVIS_TAG}; fi
   - docker images
   - ./build/process-template.sh kubernetes/razeedash-api/resource.yaml >/tmp/resource.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,17 @@ RUN apk add --upgrade --no-cache libssl1.1
 
 RUN mkdir -p /usr/src/
 ENV PATH="$PATH:/usr/src/"
+
+RUN export BUILD_TIME=`date '+%Y-%m-%d %H:%M:%S'`
+
 WORKDIR /usr/src/
 COPY --from=buildImg /usr/src /usr/src
+
+ARG BUILD_ID
+ENV BUILD_ID=${BUILD_ID}
+
+ARG BUILD_TIME
+ENV BUILD_TIME=${BUILD_TIME}
 
 EXPOSE 3333
 CMD ["npm", "start"]

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -39,6 +39,14 @@ const Resources = require('./v2/resources.js');
 const Orgs = require('./v2/orgs.js');
 const Channels = require('./v1/channels.js');
 
+router.get('/v1/health', (req, res)=>{
+  res.json({
+    success: true,
+    BUILD_ID: process.env.BUILD_ID || 'n/a',
+    BUILD_TIME: process.env.BUILD_TIME || 'n/a',
+  });
+});
+
 router.use('/kube', Kube);
 router.use(ebl(getBunyanConfig('/api/v2/')));
 


### PR DESCRIPTION
Adds these env vars at build time:
```
export BUILD_ID='2927-9e2bbda37f4b666ee983e37f4f927704f6982b33'
export BUILD_TIME='2020-07-28 15:30:27'
```
And adds /api/v1/health, which displays them.
