### PR TITLE
Field specific searching

### DIFF
--- a/app/apollo/resolvers/resource.js
+++ b/app/apollo/resolvers/resource.js
@@ -18,7 +18,7 @@ const _ = require('lodash');
 const { withFilter, ForbiddenError } = require('apollo-server');
 const GraphqlFields = require('graphql-fields');
 
-const buildSearchForResources = require('../utils');
+const { buildSearchForResources, convertStrToTextPropsObj } = require('../utils');
 const { ACTIONS, TYPES } = require('../models/const');
 const { EVENTS, GraphqlPubSub, getStreamingTopic } = require('../subscription');
 const { whoIs, validAuth, getAllowedGroups, getGroupConditionsIncludingEmpty, NotFoundError } = require ('./common');
@@ -229,7 +229,10 @@ const resourceResolvers = {
         searchFilter['searchableData.kind'] = { $in: kinds };
       }
       if ((filter && filter !== '') || fromDate != null || toDate != null) {
-        searchFilter = buildSearchForResources(searchFilter, filter, fromDate, toDate, kinds);
+        var props = convertStrToTextPropsObj(filter);
+        var textProp = props.$text || '';
+        _.assign(searchFilter, models.Resource.translateAliases(_.omit(props, '$text')));
+        searchFilter = buildSearchForResources(searchFilter, textProp, fromDate, toDate, kinds);
       }
       const resourcesResult = await commonResourcesSearch({ models, org_id, searchFilter, limit, queryFields, sort, context });
 

--- a/app/apollo/resolvers/resourceDistributed.js
+++ b/app/apollo/resolvers/resourceDistributed.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const buildSearchForResources = require('../utils');
+const buildSearchForResources = require('../utils').buildSearchForResources;
 const { ACTIONS, TYPES } = require('../models/const');
 const { whoIs, validAuth } = require ('./common');
 

--- a/app/apollo/utils/index.js
+++ b/app/apollo/utils/index.js
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+var _ = require('lodash');
+
 const buildSearchForResources = (baseSearch, searchStr = '', fromTime, toTime, kinds = []) => {
   let ands = [];
-  const tokens = searchStr.split(/\s+/);
+  const tokens = _.filter(searchStr.split(/\s+/));
   if (tokens.length > 0) {
     ands = tokens.map(token => {
       let searchRegex = {$regex: token, $options: 'i',};
@@ -63,7 +65,7 @@ const buildSearchForResources = (baseSearch, searchStr = '', fromTime, toTime, k
   }
 
   if (ands.length < 1) {
-    return null;
+    return baseSearch;
   }
   ands.push(baseSearch);
   const search = {
@@ -72,4 +74,25 @@ const buildSearchForResources = (baseSearch, searchStr = '', fromTime, toTime, k
   return search;
 };
 
-module.exports = buildSearchForResources;
+var convertStrToTextPropsObj = (str)=>{
+  var out = {};
+  // converts 'aaa bbb:ccc ddd:"eee" fff' to { bbb: 'ccc', ddd: 'eee', '$text': 'aaa    fff' }
+  var regex = /\b([a-z0-9_.-]+)\s*:\s*(["']?)([^\s]*)\2/ig;
+  str = str.replace(regex, (z, key, quote, val)=>{
+    if(!_.includes(convertStrToTextPropsObj.invalidFields, key)) {
+      out[key] = val;
+    }
+    return ' ';
+  });
+  out.$text = str;
+  return out;
+};
+convertStrToTextPropsObj.invalidFields = [
+  'orgId', 'org_id',
+];
+
+convertStrToTextPropsObj('aaa bbb:ccc ddd:"eee" fff');
+
+module.exports = {
+  buildSearchForResources, convertStrToTextPropsObj,
+};

--- a/app/apollo/utils/index.js
+++ b/app/apollo/utils/index.js
@@ -74,7 +74,7 @@ const buildSearchForResources = (baseSearch, searchStr = '', fromTime, toTime, k
   return search;
 };
 
-var convertStrToTextPropsObj = (str)=>{
+var convertStrToTextPropsObj = (str='')=>{
   var out = {};
   // converts 'aaa bbb:ccc ddd:"eee" fff' to { bbb: 'ccc', ddd: 'eee', '$text': 'aaa    fff' }
   var regex = /\b([a-z0-9_.-]+)\s*:\s*(["']?)([^\s]*)\2/ig;


### PR DESCRIPTION
Lets you add key value searches inside the search string for `resources` and `clusterSearch` endpoints.

So the search filter string of: `clean metadata.kube_version.major: 1 metadata.kube_version.minor: 17`
will change the search to:
```
{
  'metadata.kube_version.major': '1',
  'metadata.kube_version.minor': '17'
}
```
and update the text search string to only look for the word `clean`

Example in insomnia:
![image](https://user-images.githubusercontent.com/20116801/88936755-3f099d00-d251-11ea-9fce-afb2886ec1f1.png)
(the 7da4 matches part of the clusterId)