### PR TITLE
Fix unhandled exception

### DIFF
--- a/app/mongo/mongoClient.js
+++ b/app/mongo/mongoClient.js
@@ -98,9 +98,13 @@ module.exports = class MongoClient {
     const db = await this._clientConnect();
     for(let i=0; i<viewsToCreate.length;i++){
       let view = viewsToCreate[i];
-      let v=await db.createCollection(view.name, {viewOn: view.source, pipeline: view.pipeline, collation: view.options });
-      this.log.info(`Created new View ${view.name}`);
-      result.push(v);
+      try {
+        let v=await db.createCollection(view.name, {viewOn: view.source, pipeline: view.pipeline, collation: view.options });
+        this.log.info(`Created new View ${view.name}`);
+        result.push(v);
+      } catch (e) {
+        this.log.warn(e);
+      }
     }
     return result;
   }

--- a/app/mongo/mongoClient.js
+++ b/app/mongo/mongoClient.js
@@ -99,6 +99,7 @@ module.exports = class MongoClient {
     for(let i=0; i<viewsToCreate.length;i++){
       let view = viewsToCreate[i];
       try {
+        // catch the exception for views
         let v=await db.createCollection(view.name, {viewOn: view.source, pipeline: view.pipeline, collation: view.options });
         this.log.info(`Created new View ${view.name}`);
         result.push(v);


### PR DESCRIPTION
For some reason, pods crashed on the `UnhandledPromiseRejectionWarning: MongoError: a view 'sloop.clusterStatsView' already exists` exception. The PR is to catch exceptions when try to create views. 

```
 > node app/index.js
{"name":"apollo/subscription","parseUA":false,"excludes":["referer","url","body","short-body"],"hostname":"satellite-config-apollo-66f579955f-ncmcc","pid":17,"level":30,"msg":"Apollo streaming service is configured on redisUrl: rediss://xxxxxxx:yyyyyyyy@2eb0b397-c051-4bc5-a8dc-f23ccf71f713.blrrvkdw0thh68l98t20.databases.appdomain.cloud:30271/0","time":"2020-07-30T21:28:25.363Z","v":0}
{"name":"apollo/subscription","parseUA":false,"excludes":["referer","url","body","short-body"],"hostname":"satellite-config-apollo-66f579955f-ncmcc","pid":17,"level":30,"msg":"Apollo streaming is enabled on redis endpoint 2eb0b397-c051-4bc5-a8dc-f23ccf71f713.blrrvkdw0thh68l98t20.databases.appdomain.cloud:30271","time":"2020-07-30T21:28:28.302Z","v":0}
{"name":"/","parseUA":false,"excludes":["referer","url","body","short-body"],"hostname":"satellite-config-apollo-66f579955f-ncmcc","pid":17,"level":30,"msg":"Created new collection users index users","time":"2020-07-30T21:28:28.699Z","v":0}
(node:17) UnhandledPromiseRejectionWarning: MongoError: a view 'sloop.clusterStatsView' already exists
    at MessageStream.messageHandler (/usr/src/node_modules/mongodb/lib/cmap/connection.js:266:20)
    at MessageStream.emit (events.js:315:20)
    at MessageStream.EventEmitter.emit (domain.js:483:12)
    at processIncomingData (/usr/src/node_modules/mongodb/lib/cmap/message_stream.js:144:12)
    at MessageStream._write (/usr/src/node_modules/mongodb/lib/cmap/message_stream.js:42:5)
    at doWrite (_stream_writable.js:403:12)
    at writeOrBuffer (_stream_writable.js:387:5)
    at MessageStream.Writable.write (_stream_writable.js:318:11)
    at TLSSocket.ondata (_stream_readable.js:716:22)
    at TLSSocket.emit (events.js:315:20)
    at TLSSocket.EventEmitter.emit (domain.js:483:12)
    at addChunk (_stream_readable.js:295:12)
    at readableAddChunk (_stream_readable.js:271:9)
    at TLSSocket.Readable.push (_stream_readable.js:212:10)
    at TLSWrap.onStreamRead (internal/stream_base_commons.js:186:23)
(node:17) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:17) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code. 
```