### PR TITLE
Update: allow clusterInfo to be rendered for subscription-> resources…

### DIFF
--- a/app/apollo/resolvers/common.js
+++ b/app/apollo/resolvers/common.js
@@ -118,8 +118,7 @@ const validAuth = async (me, org_id, action, type, queryName, context) => {
 };
 
 // a helper function to render clusterInfo for a list of resources
-const applyClusterInfoOnResources = async (org_id, resources, context) => {
-  const {  models } = context;
+const applyClusterInfoOnResources = async (org_id, resources, models) => {
   const clusterIds = _.uniq(_.map(resources, 'cluster_id'));
   if(clusterIds.length > 0){
     let clusters = await models.Cluster.find({ org_id, cluster_id: { $in: clusterIds }}).lean({ virtuals: true });

--- a/app/apollo/resolvers/common.js
+++ b/app/apollo/resolvers/common.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const _ = require('lodash');
 const { ForbiddenError, ApolloError } = require('apollo-server');
 const { TYPES, ACTIONS } = require('../models/const');
 
@@ -114,7 +115,24 @@ const validAuth = async (me, org_id, action, type, queryName, context) => {
       `You are not allowed to ${action} on ${type} under organization ${org_id} for the query ${queryName}.`,
     );
   }
-}; 
+};
+
+// a helper function to render clusterInfo for a list of resources
+const applyClusterInfoOnResources = async (org_id, resources, context) => {
+  const {  models } = context;
+  const clusterIds = _.uniq(_.map(resources, 'cluster_id'));
+  if(clusterIds.length > 0){
+    let clusters = await models.Cluster.find({ org_id, cluster_id: { $in: clusterIds }}).lean({ virtuals: true });
+    clusters = _.map(clusters, (cluster)=>{
+      cluster.name = cluster.name || (cluster.metadata || {}).name || (cluster.registration || {}).name || cluster.cluster_id;
+      return cluster;
+    });
+    clusters = _.keyBy(clusters, 'cluster_id');
+    resources.forEach((resource)=>{
+      resource.cluster = clusters[resource.cluster_id] || null;
+    });
+  }
+};
 
 // Not Found Error when look up db
 class NotFoundError extends ApolloError {
@@ -124,4 +142,4 @@ class NotFoundError extends ApolloError {
   }
 }
 
-module.exports =  { whoIs, validAuth, NotFoundError, validClusterAuth, getAllowedGroups, getGroupConditions, getGroupConditionsIncludingEmpty };
+module.exports =  { whoIs, validAuth, NotFoundError, validClusterAuth, getAllowedGroups, getGroupConditions, getGroupConditionsIncludingEmpty , applyClusterInfoOnResources};

--- a/app/apollo/resolvers/resource.js
+++ b/app/apollo/resolvers/resource.js
@@ -40,7 +40,7 @@ const commonResourcesSearch = async ({ context, org_id, searchFilter, limit=500,
     var count = await models.Resource.find(searchFilter).count();
     // if user is requesting the cluster field (i.e cluster_id/name), then adds it to the results
     if( (queryFields.resources||{}).cluster ) {
-      applyClusterInfoOnResources(org_id, resources, context);
+      await applyClusterInfoOnResources(org_id, resources, context);
     }
     return {
       count,

--- a/app/apollo/resolvers/resource.js
+++ b/app/apollo/resolvers/resource.js
@@ -40,7 +40,7 @@ const commonResourcesSearch = async ({ context, org_id, searchFilter, limit=500,
     var count = await models.Resource.find(searchFilter).count();
     // if user is requesting the cluster field (i.e cluster_id/name), then adds it to the results
     if( (queryFields.resources||{}).cluster ) {
-      await applyClusterInfoOnResources(org_id, resources, context);
+      await applyClusterInfoOnResources(org_id, resources, models);
     }
     return {
       count,

--- a/app/apollo/resolvers/resource.js
+++ b/app/apollo/resolvers/resource.js
@@ -21,7 +21,7 @@ const GraphqlFields = require('graphql-fields');
 const { buildSearchForResources, convertStrToTextPropsObj } = require('../utils');
 const { ACTIONS, TYPES } = require('../models/const');
 const { EVENTS, GraphqlPubSub, getStreamingTopic } = require('../subscription');
-const { whoIs, validAuth, getAllowedGroups, getGroupConditionsIncludingEmpty, NotFoundError } = require ('./common');
+const { whoIs, validAuth, getAllowedGroups, getGroupConditionsIncludingEmpty, applyClusterInfoOnResources, NotFoundError } = require ('./common');
 const ObjectId = require('mongoose').Types.ObjectId;
 
 const conf = require('../../conf.js').conf;
@@ -39,19 +39,8 @@ const commonResourcesSearch = async ({ context, org_id, searchFilter, limit=500,
     ;
     var count = await models.Resource.find(searchFilter).count();
     // if user is requesting the cluster field (i.e cluster_id/name), then adds it to the results
-    if((queryFields.resources||{}).cluster){
-      const clusterIds = _.uniq(_.map(resources, 'cluster_id'));
-      if(clusterIds.length > 0){
-        let clusters = await models.Cluster.find({ org_id, cluster_id: { $in: clusterIds }}).lean({ virtuals: true });
-        clusters = _.map(clusters, (cluster)=>{
-          cluster.name = cluster.name || (cluster.metadata || {}).name || (cluster.registration || {}).name || cluster.cluster_id;
-          return cluster;
-        });
-        clusters = _.keyBy(clusters, 'cluster_id');
-        resources.forEach((resource)=>{
-          resource.cluster = clusters[resource.cluster_id] || null;
-        });
-      }
+    if( (queryFields.resources||{}).cluster ) {
+      applyClusterInfoOnResources(org_id, resources, context);
     }
     return {
       count,

--- a/app/apollo/resolvers/subscription.js
+++ b/app/apollo/resolvers/subscription.js
@@ -19,7 +19,7 @@ const { v4: UUID } = require('uuid');
 const { withFilter, ValidationError } = require('apollo-server');
 const { ForbiddenError } = require('apollo-server');
 const { ACTIONS, TYPES } = require('../models/const');
-const { whoIs, validAuth, NotFoundError, validClusterAuth, getGroupConditions, getAllowedGroups } = require ('./common');
+const { whoIs, validAuth, NotFoundError, validClusterAuth, getGroupConditions, getAllowedGroups, applyClusterInfoOnResources } = require ('./common');
 const getSubscriptionUrls = require('../../utils/subscriptions.js').getSubscriptionUrls;
 const { EVENTS, GraphqlPubSub, getStreamingTopic } = require('../subscription');
 const GraphqlFields = require('graphql-fields');
@@ -69,6 +69,9 @@ const applyQueryFieldsToSubscriptions = async(subs, queryFields, { orgId }, mode
     _.each(subs, (sub)=>{
       sub.resources = resourcesBySubUuid[sub.uuid] || [];
     });
+    if (queryFields.resources.cluster) {
+      applyClusterInfoOnResources(orgId, resources, context);
+    }
   }
   if(queryFields.groupObjs){
     var groupNames = _.flatten(_.map(subs, 'groups'));
@@ -106,6 +109,9 @@ const applyQueryFieldsToSubscriptions = async(subs, queryFields, { orgId }, mode
       });
 
       sub.remoteResources = rrs;
+      if (queryFields.remoteResources.cluster) {
+        applyClusterInfoOnResources(orgId, resources, context);
+      }
       sub.rolloutStatus = {
         successCount,
         errorCount,

--- a/app/apollo/resolvers/subscription.js
+++ b/app/apollo/resolvers/subscription.js
@@ -67,7 +67,7 @@ const applyQueryFieldsToSubscriptions = async(subs, queryFields, { orgId }, mode
     var resources = await models.Resource.find({ org_id: orgId, 'searchableData.subscription_id' : { $in: subUuids } }).lean({virtuals: true});
     var resourcesBySubUuid = _.groupBy(resources, 'searchableData.subscription_id');
     if (queryFields.resources.cluster) {
-      await applyClusterInfoOnResources(orgId, resources, context);
+      await applyClusterInfoOnResources(orgId, resources, models);
     }
     _.each(subs, (sub)=>{
       sub.resources = resourcesBySubUuid[sub.uuid] || [];
@@ -91,7 +91,7 @@ const applyQueryFieldsToSubscriptions = async(subs, queryFields, { orgId }, mode
       deleted: false,
     });
     if (queryFields.remoteResources.cluster) {
-      await applyClusterInfoOnResources(orgId, remoteResources, context);
+      await applyClusterInfoOnResources(orgId, remoteResources, models);
     }
     var remoteResourcesBySubUuid = _.groupBy(remoteResources, (rr)=>{
       return rr.searchableData.get('annotations["deploy_razee_io_clustersubscription"]');


### PR DESCRIPTION
Update: allow clusterInfo to be rendered for subscription-> resources | remoteResources -> cluster. e.g:

```
query  ($org_id:  String!, $uuid: String!) {
  subscription(orgId: $org_id, uuid: $uuid) {
      remoteResources { 
        id,
        cluster { clusterId, name }, 
      },
  }
}
```