### PR TITLE
new: restrict content type to only yaml

### DIFF
--- a/app/apollo/resolvers/channel.js
+++ b/app/apollo/resolvers/channel.js
@@ -230,8 +230,8 @@ const channelResolvers = {
       if(!name){
         throw new RazeeValidationError('A "name" must be specified', context);
       }
-      if(!type){
-        throw new RazeeValidationError('A "type" of application/json or application/yaml must be specified', context);
+      if(!type || type !== 'yaml' && type !== 'application/yaml'){
+        throw new RazeeValidationError('A "type" of application/yaml must be specified', context);
       }
       if(!channel_uuid){
         throw new RazeeValidationError('A "channel_uuid" must be specified', context);


### PR DESCRIPTION
restricting content type to only yaml. Previously allowed json and yaml