### PR TITLE
pass the channel UUID as the attribute

### DIFF
--- a/app/apollo/resolvers/channel.js
+++ b/app/apollo/resolvers/channel.js
@@ -99,7 +99,7 @@ const channelResolvers = {
       const { models, me, req_id, logger } = context;
       const queryName = _queryName ? `${_queryName}/channelVersion` : 'channelVersion';
       logger.debug({req_id, user: whoIs(me), org_id, channelUuid, versionUuid, channelName, versionName}, `${queryName} enter`);
-      await validAuth(me, org_id, ACTIONS.READ, TYPES.CHANNEL, queryName, context, channel_uuid);
+      await validAuth(me, org_id, ACTIONS.READ, TYPES.CHANNEL, queryName, context);
       try{
 
         const org = await models.Organization.findOne({ _id: org_id });
@@ -224,7 +224,6 @@ const channelResolvers = {
 
       const queryName = 'addChannelVersion';
       logger.debug({req_id, user: whoIs(me), org_id, channel_uuid, name, type, description, file }, `${queryName} enter`);
-      await validAuth(me, org_id, ACTIONS.MANAGEVERSION, TYPES.CHANNEL, queryName, context);
 
       // slightly modified code from /app/routes/v1/channelsStream.js. changed to use mongoose and graphql
       const org = await models.Organization.findOne({ _id: org_id });
@@ -250,6 +249,8 @@ const channelResolvers = {
       if(!channel){
         throw new NotFoundError(`channel uuid "${channel_uuid}" not found`, context);
       }
+
+      await validAuth(me, org_id, ACTIONS.MANAGEVERSION, TYPES.CHANNEL, queryName, context, [channel.uuid, channel.name]);
 
       const versions = await models.DeployableVersion.find({ org_id, channel_id: channel_uuid });
       const versionNameExists = !!versions.find((version)=>{

--- a/app/apollo/resolvers/channel.js
+++ b/app/apollo/resolvers/channel.js
@@ -99,7 +99,7 @@ const channelResolvers = {
       const { models, me, req_id, logger } = context;
       const queryName = _queryName ? `${_queryName}/channelVersion` : 'channelVersion';
       logger.debug({req_id, user: whoIs(me), org_id, channelUuid, versionUuid, channelName, versionName}, `${queryName} enter`);
-      await validAuth(me, org_id, ACTIONS.READ, TYPES.CHANNEL, queryName, context);
+      await validAuth(me, org_id, ACTIONS.READ, TYPES.CHANNEL, queryName, context, channel_uuid);
       try{
 
         const org = await models.Organization.findOne({ _id: org_id });

--- a/app/apollo/resolvers/common.js
+++ b/app/apollo/resolvers/common.js
@@ -95,7 +95,7 @@ const getGroupConditionsIncludingEmpty = async (me, org_id, action, field, query
 
 // Validate is user is authorized for the requested action.
 // Throw exception if not.
-const validAuth = async (me, org_id, action, type, queryName, context) => {
+const validAuth = async (me, org_id, action, type, queryName, context, attrs = null) => {
   const {req_id, models, logger} = context;
 
   if (context.recoveryHintsMap) {
@@ -113,7 +113,7 @@ const validAuth = async (me, org_id, action, type, queryName, context) => {
     }
     return;
   }
-  if (me === null || !(await models.User.isAuthorized(me, org_id, action, type, null, context))) {
+  if (me === null || !(await models.User.isAuthorized(me, org_id, action, type, attrs, context))) {
     logger.error({req_id, me: whoIs(me), org_id, action, type}, `ForbiddenError - ${queryName}`);
     throw new RazeeForbiddenError(
       `You are not allowed to ${action} on ${type} under organization ${org_id} for the query ${queryName}.`,


### PR DESCRIPTION
this should create a CRN that looks like:
`crn:v1:bluemix:public:satellite:global:a/{orgId}::configuration:{channel_uuid}`

altho, to really make this work, we may need to change it to pass the channel name:
`crn:v1:bluemix:public:satellite:global:a/{orgId}::configuration:{channel_name}`

...but that's weird.