### PR TITLE
added clusterId as an option to subscriptions in the place of groups.…

### DIFF
--- a/app/apollo/models/subscription.schema.js
+++ b/app/apollo/models/subscription.schema.js
@@ -35,6 +35,9 @@ const SubscriptionSchema = new mongoose.Schema({
       type: String,
     }
   ],
+  clusterId: {
+    type: String,
+  },
   channel_uuid: {
     type: String,
     alias: 'channelUuid',

--- a/app/apollo/resolvers/subscription.js
+++ b/app/apollo/resolvers/subscription.js
@@ -87,7 +87,10 @@ const subscriptionResolvers = {
         //   subscription groups: ['dev', 'prod'] , clusterGroupNames: ['stage'] ==> false
         var foundSubscriptions = await models.Subscription.find({
           'org_id': org_id,
-          groups: { $in: clusterGroupNames },
+          $or: [
+            { groups: { $in: clusterGroupNames } },
+            { clusterId: cluster_id },
+          ],
         }).lean(/* skip virtuals: true for now since it is class facing api. */);
         _.each(foundSubscriptions, (sub)=>{
           if(_.isUndefined(sub.channelName)){
@@ -202,7 +205,13 @@ const subscriptionResolvers = {
         //   subscription groups: ['dev', 'prod'] , clusterGroupNames: ['dev', 'prod'] ==> true
         //   subscription groups: ['dev', 'prod'] , clusterGroupNames: ['dev', 'prod', 'stage'] ==> true
         //   subscription groups: ['dev', 'prod'] , clusterGroupNames: ['stage'] ==> false
-        var subscriptions = await models.Subscription.find({org_id, groups: { $in: clusterGroupNames },}).lean({ virtuals: true });
+        var subscriptions = await models.Subscription.find({
+          org_id,
+          $or: [
+            { groups: { $in: clusterGroupNames } },
+            { clusterId: cluster_id },
+          ],
+        }).lean({ virtuals: true });
         subscriptions = await filterSubscriptionsToAllowed(me, org_id, ACTIONS.READ, TYPES.SUBSCRIPTION, subscriptions, context);
       }catch(err){
         logger.error(err);
@@ -256,7 +265,13 @@ const subscriptionResolvers = {
         //   subscription groups: ['dev', 'prod'] , clusterGroupNames: ['dev', 'prod'] ==> true
         //   subscription groups: ['dev', 'prod'] , clusterGroupNames: ['dev', 'prod', 'stage'] ==> true
         //   subscription groups: ['dev', 'prod'] , clusterGroupNames: ['stage'] ==> false
-        var subscriptions = await models.Subscription.find({org_id, groups: { $in: clusterGroupNames },}).lean({ virtuals: true });
+        var subscriptions = await models.Subscription.find({
+          org_id,
+          $or: [
+            { groups: { $in: clusterGroupNames } },
+            { clusterId: cluster.cluster_id },
+          ]
+        }).lean({ virtuals: true });
         subscriptions = await filterSubscriptionsToAllowed(me, org_id, ACTIONS.READ, TYPES.SUBSCRIPTION, subscriptions, context);
       }catch(err){
         logger.error(err);
@@ -277,7 +292,7 @@ const subscriptionResolvers = {
     }
   },
   Mutation: {
-    addSubscription: async (parent, { orgId: org_id, name, groups, channelUuid: channel_uuid, versionUuid: version_uuid }, context)=>{
+    addSubscription: async (parent, { orgId: org_id, name, groups=[], channelUuid: channel_uuid, versionUuid: version_uuid, clusterId=null }, context)=>{
       const { models, me, req_id, logger } = context;
       const queryName = 'addSubscription';
       logger.debug({req_id, user: whoIs(me), org_id }, `${queryName} enter`);
@@ -312,7 +327,8 @@ const subscriptionResolvers = {
         await models.Subscription.create({
           _id: UUID(),
           uuid, org_id, name, groups, owner: me._id,
-          channelName: channel.name, channel_uuid, version: version.name, version_uuid
+          channelName: channel.name, channel_uuid, version: version.name, version_uuid,
+          clusterId,
         });
 
         pubSub.channelSubChangedFunc({org_id: org_id}, context);
@@ -329,7 +345,7 @@ const subscriptionResolvers = {
         throw new RazeeQueryError(`Query ${queryName} error. ${err.message}`, context);
       }
     },
-    editSubscription: async (parent, { orgId, uuid, name, groups, channelUuid: channel_uuid, versionUuid: version_uuid }, context)=>{
+    editSubscription: async (parent, { orgId, uuid, name, groups=[], channelUuid: channel_uuid, versionUuid: version_uuid, clusterId=null }, context)=>{
       const { models, me, req_id, logger } = context;
       const queryName = 'editSubscription';
       logger.debug({req_id, user: whoIs(me), orgId }, `${queryName} enter`);
@@ -363,6 +379,7 @@ const subscriptionResolvers = {
         var sets = {
           name, groups,
           channelName: channel.name, channel_uuid, version: version.name, version_uuid,
+          clusterId,
         };
         await models.Subscription.updateOne({ uuid, org_id: orgId, }, { $set: sets });
 

--- a/app/apollo/schema/subscription.js
+++ b/app/apollo/schema/subscription.js
@@ -113,12 +113,12 @@ const subscriptionSchema = gql`
      """
      Adds a subscription
      """
-     addSubscription(orgId: String! @sv, name: String! @sv, groups: [String!] @sv, channelUuid: String! @sv, versionUuid: String! @sv, clusterId: String): AddChannelSubscriptionReply!
+     addSubscription(orgId: String! @sv, name: String! @sv, groups: [String!] @sv, channelUuid: String! @sv, versionUuid: String! @sv, clusterId: String @sv): AddChannelSubscriptionReply!
      
      """
      Edits a subscription
      """
-     editSubscription(orgId: String! @sv, uuid: String! @sv, name: String! @sv, groups: [String!]! @sv, channelUuid: String! @sv, versionUuid: String! @sv, clusterId: String): EditChannelSubscriptionReply!
+     editSubscription(orgId: String! @sv, uuid: String! @sv, name: String! @sv, groups: [String!]! @sv, channelUuid: String! @sv, versionUuid: String! @sv, clusterId: String  @sv): EditChannelSubscriptionReply!
      
      """
      Set a configurationVersion

--- a/app/apollo/schema/subscription.js
+++ b/app/apollo/schema/subscription.js
@@ -42,6 +42,7 @@ const subscriptionSchema = gql`
     orgId: String!
     name: String!
     groups: [String!]
+    clusterId: String
     channelUuid: String!
     channelName: String!
     channel: Channel
@@ -112,12 +113,12 @@ const subscriptionSchema = gql`
      """
      Adds a subscription
      """
-     addSubscription(orgId: String! @sv, name: String! @sv, groups: [String!]! @sv, channelUuid: String! @sv, versionUuid: String! @sv): AddChannelSubscriptionReply!
+     addSubscription(orgId: String! @sv, name: String! @sv, groups: [String!] @sv, channelUuid: String! @sv, versionUuid: String! @sv, clusterId: String): AddChannelSubscriptionReply!
      
      """
      Edits a subscription
      """
-     editSubscription(orgId: String! @sv, uuid: String! @sv, name: String! @sv, groups: [String!]! @sv, channelUuid: String! @sv, versionUuid: String! @sv): EditChannelSubscriptionReply!
+     editSubscription(orgId: String! @sv, uuid: String! @sv, name: String! @sv, groups: [String!]! @sv, channelUuid: String! @sv, versionUuid: String! @sv, clusterId: String): EditChannelSubscriptionReply!
      
      """
      Set a configurationVersion


### PR DESCRIPTION
Added clusterId as an option to subscriptions in the place of groups.
Used when users want to assign a sub to a single specific cluster and not be bothered by creating groups.