### PR TITLE
To avoid logging user PII when logging user info, prioritize user 'id…

### DIFF
--- a/app/apollo/resolvers/common.js
+++ b/app/apollo/resolvers/common.js
@@ -19,8 +19,8 @@ const { TYPES, ACTIONS } = require('../models/const');
 
 const whoIs = me => {
   if (me === null || me === undefined) return 'null';
-  if (me.email) return me.email;
   if (me.identifier) return me.identifier;
+  if (me.email) return me.email;
   if (me.type) return me.type;
   return me._id;
 };


### PR DESCRIPTION
…entifier' over user 'email' attribute.