### PR TITLE
Avoid double-application of CORS middleware

### DIFF
--- a/app/apollo/index.js
+++ b/app/apollo/index.js
@@ -17,6 +17,7 @@
 const http = require('http');
 const express = require('express');
 const router = express.Router();
+const cors = require('cors');
 const { ApolloServer } = require('apollo-server-express');
 const addRequestId = require('express-request-id')();
 const { IdentifierDirective, JsonDirective } = require('./utils/directives');
@@ -210,6 +211,7 @@ const apollo = async (options = {}) => {
     const server = createApolloServer();
     server.applyMiddleware({
       app,
+      cors: cors({origin: true}),
       path: GRAPHQL_PATH,
       onHealthCheck: async () => {
         if (SIGTERM) {

--- a/app/apollo/init.local.js
+++ b/app/apollo/init.local.js
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-const cors = require('cors');
 const { SECRET } = require('./models/const');
 
 const initApp = (app, models, logger) => {
   logger.info('Initialize apollo application for local auth');
-  app.use(cors());
 };
 
 const buildApolloContext = async ({ models, req, res, connection, logger }) => {

--- a/app/apollo/test/externalAuth/init.local.js
+++ b/app/apollo/test/externalAuth/init.local.js
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-const cors = require('cors');
 const { SECRET } = require('../../models/const');
 
 const initApp = (app, models, logger) => {
   logger.info('Initialize apollo application for local auth');
-  app.use(cors());
 };
 
 const buildApolloContext = async ({ models, req, res, connection, logger }) => {


### PR DESCRIPTION
Block Access-Control-Allow-Origin: * (wildcard) regardless of AUTH_MODEL