### PR TITLE
consistent use of limit and skip on apis, allowing pagination

### DIFF
--- a/app/apollo/schema/resource.js
+++ b/app/apollo/schema/resource.js
@@ -58,6 +58,7 @@ const resourceSchema = gql`
   }
   type ResourceHistList{
     count: Int
+    totalCount: Int
     items: [ResourceHistObj!]!
   }
   type ResourceContentObj{

--- a/app/apollo/schema/resource.js
+++ b/app/apollo/schema/resource.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 IBM Corp. All Rights Reserved.
+ * Copyright 2020, 2022 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 const { gql } = require('apollo-server-express');
 
 const resourceSchema = gql`
-  
+
   type ClusterInfo {
     clusterId: String!
     name: String!
@@ -51,7 +51,7 @@ const resourceSchema = gql`
     totalCount: Int
     resources: [Resource!]!
   }
-  
+
   type ResourceHistObj{
     id: String!
     updated: Date!
@@ -66,7 +66,7 @@ const resourceSchema = gql`
     content: String!
     updated: Date!
   }
-  
+
   extend type Query {
     """
     Return total resource count for given **orgId**.
@@ -92,7 +92,7 @@ const resourceSchema = gql`
     """
     Search resources against **orgId**, **clusterId**, **filter** string, and date ranges.
     """
-    resourcesByCluster(orgId: String! @sv clusterId: String! @sv filter: String @sv limit: Int = 500): ResourcesList!
+    resourcesByCluster(orgId: String! @sv, clusterId: String! @sv, filter: String @sv, limit: Int = 500, skip: Int = 0): ResourcesList!
 
     """
     Return the resource by given resource **id**.
@@ -102,17 +102,17 @@ const resourceSchema = gql`
     """
     return the resource by given **orgId**, **clusterId** and **selfLink** of the resource.
     """
-    resourceByKeys(orgId: String! @sv clusterId: String! @sv selfLink: String! @sv): Resource
+    resourceByKeys(orgId: String! @sv, clusterId: String! @sv, selfLink: String! @sv): Resource
 
     """
     Search resources against **orgId** and **subscriptionId**.
     """
-    resourcesBySubscription(orgId: String! @sv subscriptionId: String! @sv): ResourcesList!
+    resourcesBySubscription(orgId: String! @sv, subscriptionId: String! @sv, limit: Int = 500, skip: Int = 0): ResourcesList!
     """
     Gets the yaml history for a resource
     """
-    resourceHistory(orgId: String! @sv, clusterId: String! @sv, resourceSelfLink: String! @sv, beforeDate: Date, afterDate: Date, limit: Int = 20): ResourceHistList!
-    
+    resourceHistory(orgId: String! @sv, clusterId: String! @sv, resourceSelfLink: String! @sv, beforeDate: Date, afterDate: Date, limit: Int = 20, skip: Int = 0): ResourceHistList!
+
     """
     Gets the content for a yaml hist item
     """

--- a/app/apollo/test/api.js
+++ b/app/apollo/test/api.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 IBM Corp. All Rights Reserved.
+ * Copyright 2020, 2022 IBM Corp. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -174,9 +174,10 @@ const apiFunc = grahqlUrl => {
       grahqlUrl,
       {
         query: `
-          query($orgId: String!, $clusterId: String!, $resourceSelfLink: String!, $beforeDate: Date, $afterDate: Date, $limit: Int = 20) {
-            resourceHistory(orgId: $orgId, clusterId: $clusterId, resourceSelfLink: $resourceSelfLink, beforeDate: $beforeDate, afterDate: $afterDate, limit: $limit) {
+          query($orgId: String!, $clusterId: String!, $resourceSelfLink: String!, $beforeDate: Date, $afterDate: Date, $limit: Int, $skip: Int) {
+            resourceHistory(orgId: $orgId, clusterId: $clusterId, resourceSelfLink: $resourceSelfLink, beforeDate: $beforeDate, afterDate: $afterDate, limit: $limit, skip: $skip) {
               count,
+              totalCount,
               items{
                 id
                 updated
@@ -242,8 +243,8 @@ const apiFunc = grahqlUrl => {
       grahqlUrl,
       {
         query: `
-          query($orgId: String! $filter: String $fromDate: Date $toDate: Date, $kinds: [String!], $sort: [SortObj!], $limit: Int){
-            resources(orgId: $orgId filter: $filter fromDate: $fromDate toDate: $toDate, kinds: $kinds, sort: $sort, limit: $limit) {
+          query($orgId: String!, $filter: String, $fromDate: Date, $toDate: Date, $kinds: [String!], $sort: [SortObj!], $limit: Int, $skip: Int){
+            resources(orgId: $orgId, filter: $filter, fromDate: $fromDate, toDate: $toDate, kinds: $kinds, sort: $sort, limit: $limit, skip: $skip) {
               count,
               totalCount
               resources{
@@ -277,9 +278,10 @@ const apiFunc = grahqlUrl => {
       grahqlUrl,
       {
         query: `
-          query($orgId: String! $clusterId: String! $filter: String){
-            resourcesByCluster(orgId: $orgId clusterId: $clusterId filter: $filter) {
+          query($orgId: String!, $clusterId: String!, $filter: String, $limit: Int, $skip: Int){
+            resourcesByCluster(orgId: $orgId, clusterId: $clusterId, filter: $filter, limit: $limit, skip: $skip) {
               count
+              totalCount
               resources{
                 id
                 orgId
@@ -305,9 +307,10 @@ const apiFunc = grahqlUrl => {
       grahqlUrl,
       {
         query: `
-          query($orgId: String! $subscriptionId: String!){
-            resourcesBySubscription(orgId: $orgId subscriptionId: $subscriptionId ) {
+          query($orgId: String!, $subscriptionId: String!, $limit: Int, $skip: Int){
+            resourcesBySubscription(orgId: $orgId, subscriptionId: $subscriptionId, limit: $limit, skip: $skip) {
               count
+              totalCount
               resources{
                 id
                 orgId

--- a/local-dev/api/apiMultiResourceCreate.sh
+++ b/local-dev/api/apiMultiResourceCreate.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+COUNT=${1:-1000}
+CLUSTER_ID=${2:-${RAZEE_CLUSTER_ID:-pTestClusterId}}
+RAZEE_ORG_KEY=${3:-${RAZEE_ORG_KEY:-pOrgKey}}
+
+RAZEE_URL=${RAZEE_URL:-http://localhost:3333/api/v2/clusters}
+
+[ ! -z "${RAZEE_USER_TOKEN}" ] && AUTH_HEADER="Authorization: Bearer ${RAZEE_USER_TOKEN}" || AUTH_HEADER="no-auth-available: asdf"
+
+echo
+echo "CLUSTER_ID: ${CLUSTER_ID}"
+echo
+
+
+echo "POST to ${RAZEE_URL}/${CLUSTER_ID}/resources ${COUNT} times..."
+for ((i=0;i<$COUNT;i++)); do
+  curl \
+  -X POST \
+  -H "${AUTH_HEADER}" \
+  -H "razee-org-key: ${RAZEE_ORG_KEY}" \
+  -H "Content-Type: application/json" \
+  -w "HTTP: %{http_code}" \
+  --data '[
+  { "type": "'"MODIFIED"'", "object": { "metadata": { "selfLink": "'"multiResource-${i}"'" }, "dummykey": "'"$(date)"'", "status": { "razee-logs": { "error": { "0123456789abcdef": "Test Error." } } } } }
+  ]' \
+  ${RAZEE_URL}/${CLUSTER_ID}/resources
+done
+
+retVal=$?
+
+echo
+echo "Code: $retVal"

--- a/local-dev/api/clusterList.sh
+++ b/local-dev/api/clusterList.sh
@@ -2,11 +2,12 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-RAZEE_ORG_ID=${1:-${RAZEE_ORG_ID:-pOrgId}}
-RAZEE_CLUSTER_FILTER=${2}
+RAZEE_CLUSTER_LIMIT=${1:-100}
+RAZEE_CLUSTER_FILTER=${2:-.*}
+RAZEE_ORG_ID=${3:-${RAZEE_ORG_ID:-pOrgId}}
 
 RAZEE_QUERY='query($orgId: String! $filter: String $limit: Int) { clusterSearch( orgId: $orgId filter: $filter limit: $limit) { orgId clusterId created updated metadata registration status } }'
-RAZEE_VARIABLES='{"orgId":"'"${RAZEE_ORG_ID}"'","filter":"'"${RAZEE_CLUSTER_FILTER}"'","limit":100}'
+RAZEE_VARIABLES='{"orgId":"'"${RAZEE_ORG_ID}"'","filter":"'"${RAZEE_CLUSTER_FILTER}"'","limit":'${RAZEE_CLUSTER_LIMIT}'}'
 
 echo "" && echo "LIST clusters"
 ${SCRIPT_DIR}/graphqlPost.sh "${RAZEE_QUERY}" "${RAZEE_VARIABLES}"

--- a/local-dev/api/historyList.sh
+++ b/local-dev/api/historyList.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+RAZEE_CLUSTER_ID=${1:-${RAZEE_CLUSTER_ID:-pClusterId}}
+RAZEE_RESOURCE_LINK=${2:-${RAZEE_RESOURCE_LINK:-pResourceLink}}
+LIMIT=${3:-999999}
+SKIP=${4:-0}
+RAZEE_ORG_ID=${5:-${RAZEE_ORG_ID:-pOrgId}}
+
+RAZEE_QUERY='
+query (
+  $orgId: String! $clusterId: String! $resourceSelfLink: String! $limit: Int $skip: Int
+){
+  resourceHistory(orgId: $orgId clusterId: $clusterId resourceSelfLink: $resourceSelfLink limit: $limit skip: $skip) {
+    count
+    items {
+      id
+      updated
+    }
+  }
+}
+'
+RAZEE_QUERY=$(echo $RAZEE_QUERY | tr '\n' ' ')
+RAZEE_VARIABLES='{"orgId":"'"${RAZEE_ORG_ID}"'","clusterId":"'"${RAZEE_CLUSTER_ID}"'","resourceSelfLink":"'"${RAZEE_RESOURCE_LINK}"'","limit":'${LIMIT}',"skip":'${SKIP}'}'
+
+echo "" && echo "LIST resourceHistory"
+${SCRIPT_DIR}/graphqlPost.sh "${RAZEE_QUERY}" "${RAZEE_VARIABLES}"
+echo "" && echo "Result: $?"

--- a/local-dev/api/resourceList.sh
+++ b/local-dev/api/resourceList.sh
@@ -2,33 +2,20 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-RAZEE_ORG_ID=${1:-${RAZEE_ORG_ID:-pOrgId}}
+LIMIT=${1:-999999}
+SKIP=${2:-0}
+RAZEE_ORG_ID=${3:-${RAZEE_ORG_ID:-pOrgId}}
 
 RAZEE_QUERY='
 query(
-  $orgId: String!, $filter: String, $fromDate: Date, $toDate: Date, $kinds: [String!], $sort: [SortObj!], $limit: Int
+  $orgId: String!, $limit: Int, $skip: Int
 )
 {
   resources(
-    orgId: $orgId, filter: $filter, fromDate: $fromDate, toDate: $toDate, kinds: $kinds, sort: $sort, limit: $limit
+    orgId: $orgId, limit: $limit, skip: $skip
   ) {
     count
-    resources {
-      orgId
-      selfLink
-      clusterId
-    }
-  }
-}
-'
-RAZEE_QUERY='
-query(
-  $orgId: String!
-)
-{
-  resources(
-    orgId: $orgId
-  ) {
+    totalCount
     resources {
       orgId
       selfLink
@@ -38,9 +25,8 @@ query(
 }
 '
 RAZEE_QUERY=$(echo $RAZEE_QUERY | tr '\n' ' ')
-RAZEE_VARIABLES='{"orgId":"'"${RAZEE_ORG_ID}"'"}'
-#,"limit":100
+RAZEE_VARIABLES='{"orgId":"'"${RAZEE_ORG_ID}"'","limit":'${LIMIT}',"skip":'${SKIP}'}'
 
-echo "" && echo "LIST resources (LIMIT 400)"
+echo "" && echo "LIST resources for org"
 ${SCRIPT_DIR}/graphqlPost.sh "${RAZEE_QUERY}" "${RAZEE_VARIABLES}"
 echo "" && echo "Result: $?"

--- a/local-dev/api/resourceListByCluster.sh
+++ b/local-dev/api/resourceListByCluster.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+RAZEE_CLUSTER_ID=${1:-${RAZEE_CLUSTER_ID:-pClusterId}}
+LIMIT=${2:-999999}
+SKIP=${3:-0}
+RAZEE_ORG_ID=${4:-${RAZEE_ORG_ID:-pOrgId}}
+
+RAZEE_QUERY='
+query(
+  $orgId: String!, $clusterId: String!, $limit: Int, $skip: Int
+)
+{
+  resourcesByCluster(
+    orgId: $orgId, clusterId: $clusterId, limit: $limit, skip: $skip
+  ) {
+    count
+    totalCount
+    resources {
+      orgId
+      selfLink
+      clusterId
+    }
+  }
+}
+'
+RAZEE_QUERY=$(echo $RAZEE_QUERY | tr '\n' ' ')
+RAZEE_VARIABLES='{"orgId":"'"${RAZEE_ORG_ID}"'","clusterId":"'"${RAZEE_CLUSTER_ID}"'","limit":'${LIMIT}',"skip":'${SKIP}'}'
+
+echo "" && echo "LIST resources for cluster"
+${SCRIPT_DIR}/graphqlPost.sh "${RAZEE_QUERY}" "${RAZEE_VARIABLES}"
+echo "" && echo "Result: $?"


### PR DESCRIPTION
Updated local-dev scripts to use skip and limit for testing purposes
https://github.ibm.com/alchemy-containers/satellite-config/issues/1451


- Consistently support `skip` and `limit` for  pagination in resource and resourceHistory queries
  - Prior code using a post-query `filterNamespaces` would not allow pagination to work (see inline comments for details).
- Clean up automated tests