### PR TITLE
fix gaps in rbac sync

### DIFF
--- a/app/apollo/resolvers/subscription.js
+++ b/app/apollo/resolvers/subscription.js
@@ -406,19 +406,19 @@ const subscriptionResolvers = {
         if( updateClusterIdentity ) {
           // If resyncing, trigger RBAC Sync of all clusters
           syncNeeded = true;
-          resyncNeeded = true
+          resyncNeeded = true;
         }
         else if( me._id != subscription.owner ) {
           // If changing owner, trigger RBAC Sync of any un-synced clusters
           syncNeeded = true;
-          resyncNeeded = true
+          resyncNeeded = false;
         } else {
           // If adding any new group(s), trigger RBAC Sync of any un-synced clusters
           for( const group of groups ) {
             if( !subscription.groups.includes(group) ) {
               // At least one new group, trigger sync and stop checking for new groups
               syncNeeded = true;
-              resyncNeeded = true
+              resyncNeeded = false;
               break;
             }
           }

--- a/app/apollo/resolvers/subscription.js
+++ b/app/apollo/resolvers/subscription.js
@@ -386,8 +386,12 @@ const subscriptionResolvers = {
 
         // RBAC Sync
         if( updateClusterIdentity ) {
+          const kubeOwnerId = await models.User.getKubeOwnerId(context);
           sets['owner'] = me._id;
-          subscription.owner = me._id; // Set the new owner on the subscription object before performing RBAC Sync based on it
+          sets['kubeOwnerId'] = kubeOwnerId;
+          // Set the new owner on the subscription object before performing RBAC Sync based on it
+          subscription.owner = me._id;
+          subscription.kubeOwnerId = kubeOwnerId;
         }
 
         await models.Subscription.updateOne({ uuid, org_id: orgId, }, { $set: sets });

--- a/app/apollo/resolvers/subscription.js
+++ b/app/apollo/resolvers/subscription.js
@@ -385,7 +385,10 @@ const subscriptionResolvers = {
         };
 
         // RBAC Sync
-        if( updateClusterIdentity ) sets['owner'] = me._id; //kubeOwnerId?
+        if( updateClusterIdentity ) {
+          sets['owner'] = me._id;
+          subscription.owner = me._id; // Set the new owner on the subscription object before performing RBAC Sync based on it
+        }
 
         await models.Subscription.updateOne({ uuid, org_id: orgId, }, { $set: sets });
 
@@ -397,6 +400,7 @@ const subscriptionResolvers = {
         RBAC Sync completes asynchronously, so no `await`.
         Even if RBAC Sync errors, subscription edit is successful.
         */
+        subscription.groups = groups; // Set the new groups on the subscription object before performing RBAC Sync based on it
         if( updateClusterIdentity ) {
           // If resyncing, trigger RBAC Sync of all clusters
           subscriptionsRbacSync( [subscription], { resync: true }, context ).catch(function(){/*ignore*/});

--- a/local-dev/api/subRemoveGroups.sh
+++ b/local-dev/api/subRemoveGroups.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+RAZEE_SUB_NAME=${1:-${RAZEE_SUB_NAME:-pSubName}}
+RAZEE_SUB_UUID=${2:-${RAZEE_SUB_UUID:-pSubUuid}}
+RAZEE_ORG_ID=${3:-${RAZEE_ORG_ID:-pOrgId}}
+RAZEE_CONFIG_UUID=${4:-${RAZEE_CONFIG_UUID:-pConfigUuid}}
+RAZEE_VER_UUID=${5:-${RAZEE_VER_UUID:-pVerUuid}}
+
+RAZEE_QUERY='mutation($orgId: String!, $uuid: String!, $name: String!, $groups: [String!]!, $channelUuid: String!, $versionUuid: String!) { editSubscription( orgId: $orgId, uuid: $uuid, name: $name, groups: $groups, channelUuid: $channelUuid, versionUuid: $versionUuid ) { uuid } }'
+RAZEE_VARIABLES='{"orgId":"'"${RAZEE_ORG_ID}"'","uuid":"'"${RAZEE_SUB_UUID}"'","name":"'"${RAZEE_SUB_NAME}"'","groups":[],"channelUuid":"'"${RAZEE_CONFIG_UUID}"'","versionUuid":"'"${RAZEE_VER_UUID}"'"}'
+
+echo "" && echo "EDIT subscription to REMOVE ALL GROUPS"
+${SCRIPT_DIR}/graphqlPost.sh "${RAZEE_QUERY}" "${RAZEE_VARIABLES}"
+echo "" && echo "Result: $?"


### PR DESCRIPTION
- Correctly retrieves and sets kubeOwnerId when changing subscription owner
- Updates subscription object with saved changes before calling RBAC Sync (rbac sync won't **re**-retrieve the sub object from db before processing)
- Add utility script to unset groups for a subscription