### PR TITLE
Orgkey encryption

### DIFF
--- a/app/apollo/models/deployableVersion.schema.js
+++ b/app/apollo/models/deployableVersion.schema.js
@@ -42,6 +42,13 @@ const DeployableVersionSchema = new mongoose.Schema({
     type: String,
   },
   content: mongoose.Schema.Types.Mixed,
+  /*PLC*/
+  verifiedOrgKeyUuid: {
+    type: String,
+  },
+  desiredOrgKeyUuid: {
+    type: String,
+  },
   iv: {
     type: String,
   },

--- a/app/apollo/models/deployableVersion.schema.js
+++ b/app/apollo/models/deployableVersion.schema.js
@@ -42,13 +42,13 @@ const DeployableVersionSchema = new mongoose.Schema({
     type: String,
   },
   content: mongoose.Schema.Types.Mixed,
-  /*PLC*/
   verifiedOrgKeyUuid: {
     type: String,
   },
   desiredOrgKeyUuid: {
     type: String,
   },
+  /* iv is only used for legacy data, see ../utils/versionUtils.js for additional details */
   iv: {
     type: String,
   },

--- a/app/apollo/models/organization.local.schema.js
+++ b/app/apollo/models/organization.local.schema.js
@@ -16,7 +16,7 @@
 
 const mongoose = require('mongoose');
 const { v4: uuid } = require('uuid');
-const { bestOrgKeyValue } = require('../../utils/orgs');
+const { bestOrgKey } = require('../../utils/orgs');
 const OrganizationLocalSchema = new mongoose.Schema({
   _id: {
     type: String,
@@ -71,7 +71,7 @@ OrganizationLocalSchema.statics.getRegistrationUrl = async function(org_id, cont
     host = process.env.EXTERNAL_HOST;
   }
   return {
-    url: `${protocol}://${host}/api/install/razeedeploy-job?orgKey=${bestOrgKeyValue(org)}`,
+    url: `${protocol}://${host}/api/install/razeedeploy-job?orgKey=${bestOrgKey(org).key}`,
   };
 };
 

--- a/app/apollo/resolvers/channel.js
+++ b/app/apollo/resolvers/channel.js
@@ -23,6 +23,7 @@ const pLimit = require('p-limit');
 const { applyQueryFieldsToChannels, applyQueryFieldsToDeployableVersions } = require('../utils/applyQueryFields');
 const storageFactory = require('./../../storage/storageFactory');
 const yaml = require('js-yaml');
+const { bestOrgKey, getOrgKeyByUuid } = require('../../utils/orgs.js');  //PLC
 
 const { ACTIONS, TYPES, CHANNEL_VERSION_YAML_MAX_SIZE_LIMIT_MB, CHANNEL_LIMITS, CHANNEL_VERSION_LIMITS } = require('../models/const');
 const { whoIs, validAuth, getAllowedChannels, filterChannelsToAllowed, NotFoundError, RazeeValidationError, BasicRazeeError, RazeeQueryError} = require ('./common');
@@ -134,7 +135,7 @@ const channelResolvers = {
         if (!org) {
           throw new NotFoundError(context.req.t('Could not find the organization with ID {{org_id}}.', {'org_id':org_id}), context);
         }
-        const orgKey = _.first(org.orgKeys);  //PLC this is problematic
+        //PLC const orgKey = _.first(org.orgKeys);  //PLC this is problematic
 
         // search channel by channel uuid or channel name
         const channelFilter = channelName ? { name: channelName, org_id } : { uuid: channelUuid, org_id } ;
@@ -161,11 +162,12 @@ const channelResolvers = {
           logger.info({req_id, user: whoIs(me), org_id, channelUuid, versionUuid, channelName, versionName }, `${queryName} found ${versionObjs.length} matching versions` );
           throw new RazeeValidationError(context.req.t('More than one {{type}} matches {{name}}', {'type':'version', 'name':versionName}), context);
         }
-        const versionObj = versionObjs[0] || null;
 
+        const versionObj = versionObjs[0] || null;
         if (!versionObj) {
           throw new NotFoundError(context.req.t('versionObj "{{versionUuid}}" is not found for {{channel.name}}:{{channel.uuid}}', {'versionUuid':versionUuid, 'channel.name':channel.name, 'channel.uuid':channel.uuid}), context);
         }
+
         const version_uuid = versionObj.uuid; // in case query by versionName, populate version_uuid
         const deployableVersionObj = await models.DeployableVersion.findOne({org_id, channel_id: channel_uuid, uuid: version_uuid });
         if (!deployableVersionObj) {
@@ -174,7 +176,22 @@ const channelResolvers = {
         await applyQueryFieldsToDeployableVersions([ deployableVersionObj ], queryFields, { orgId: org_id }, context);
 
         const handler = storageFactory(logger).deserialize(deployableVersionObj.content);
-        deployableVersionObj.content = await handler.getDataAndDecrypt(orgKey, deployableVersionObj.iv);  //PLC this is where it's dangerous
+        //PLC deployableVersionObj.content = await handler.getDataAndDecrypt(orgKey, deployableVersionObj.iv);
+        try {
+          const orgKey = getOrgKeyByUuid( org, versionObj.desiredOrgKeyUuid || org.orgKeys[0] );
+          deployableVersionObj.content = await handler.getDataAndDecrypt(orgKey.key, deployableVersionObj.iv);
+        }
+        catch( decryptError1 ) {
+          logger.warn(decryptError1, `${queryName} encountered an error when decrypting version '${versionObj.uuid}' with desiredOrgKeyUuid for request ${req_id}: ${decryptError1.message}`);
+          try {
+            const orgKey = getOrgKeyByUuid( org, versionObj.verifiedOrgKeyUuid || org.orgKeys[0] );
+            deployableVersionObj.content = await handler.getDataAndDecrypt(orgKey.key, deployableVersionObj.iv);
+          }
+          catch( decryptError2 ) {
+            logger.error(decryptError2, `${queryName} encountered an error when decrypting version '${versionObj.uuid}' with verifiedOrgKeyUuid for request ${req_id}: ${decryptError2.message}`);
+            throw new RazeeQueryError(context.req.t('Query {{queryName}} error. MessageID: {{req_id}}.', {'queryName':queryName, 'req_id':req_id}), context);
+          }
+        }
 
         return deployableVersionObj;
       }catch(err){
@@ -295,7 +312,6 @@ const channelResolvers = {
       if (!org) {
         throw new NotFoundError(context.req.t('Could not find the organization with ID {{org_id}}.', {'org_id':org_id}), context);
       }
-      const orgKey = _.first(org.orgKeys);  //PLC this is problematic
 
       if(!name){
         throw new RazeeValidationError(context.req.t('A "name" must be specified'), context);
@@ -318,13 +334,15 @@ const channelResolvers = {
       await validAuth(me, org_id, ACTIONS.MANAGEVERSION, TYPES.CHANNEL, queryName, context, [channel.uuid, channel.name]);
 
       const versions = await models.DeployableVersion.find({ org_id, channel_id: channel_uuid });
+
+      // Prevent duplicate names
       const versionNameExists = !!versions.find((version)=>{
         return (version.name == name);
       });
-
       if(versionNameExists) {
         throw new RazeeValidationError(context.req.t('The version name {{name}} already exists', {'name':name}), context);
       }
+
       // validate the number of total configuration channel versions are under the limit
       const total = await models.DeployableVersion.count({org_id, channel_id: channel_uuid});
       if (total >= CHANNEL_VERSION_LIMITS.MAX_TOTAL ) {
@@ -353,7 +371,8 @@ const channelResolvers = {
       const path = `${org_id.toLowerCase()}-${channel.uuid}-${newVerUuid}`;
       const bucketName = conf.storage.getChannelBucket(channel.data_location);
       const handler = storageFactory(logger).newResourceHandler(path, bucketName, channel.data_location);
-      const ivText = await handler.setDataAndEncrypt(content, orgKey);  //PLC this is where it's dangerous
+      const orgKey = bestOrgKey( org ); //PLC
+      const ivText = await handler.setDataAndEncrypt(content, orgKey.key);  //PLC
       const data = handler.serialize();
 
       const kubeOwnerId = await models.User.getKubeOwnerId(context);
@@ -370,6 +389,9 @@ const channelResolvers = {
         type,
         ownerId: me._id,
         kubeOwnerId,
+        //PLC
+        verifiedOrgKeyUuid: orgKey.orgKeyUuid,
+        desiredOrgKeyUuid: orgKey.orgKeyUuid,
       };
 
       // Note: if failure occurs here, the data has already been stored by storageFactory.

--- a/app/apollo/resolvers/channel.js
+++ b/app/apollo/resolvers/channel.js
@@ -134,7 +134,7 @@ const channelResolvers = {
         if (!org) {
           throw new NotFoundError(context.req.t('Could not find the organization with ID {{org_id}}.', {'org_id':org_id}), context);
         }
-        const orgKey = _.first(org.orgKeys);
+        const orgKey = _.first(org.orgKeys);  //PLC this is problematic
 
         // search channel by channel uuid or channel name
         const channelFilter = channelName ? { name: channelName, org_id } : { uuid: channelUuid, org_id } ;
@@ -174,7 +174,7 @@ const channelResolvers = {
         await applyQueryFieldsToDeployableVersions([ deployableVersionObj ], queryFields, { orgId: org_id }, context);
 
         const handler = storageFactory(logger).deserialize(deployableVersionObj.content);
-        deployableVersionObj.content = await handler.getDataAndDecrypt(orgKey, deployableVersionObj.iv);
+        deployableVersionObj.content = await handler.getDataAndDecrypt(orgKey, deployableVersionObj.iv);  //PLC this is where it's dangerous
 
         return deployableVersionObj;
       }catch(err){
@@ -295,7 +295,7 @@ const channelResolvers = {
       if (!org) {
         throw new NotFoundError(context.req.t('Could not find the organization with ID {{org_id}}.', {'org_id':org_id}), context);
       }
-      const orgKey = _.first(org.orgKeys);
+      const orgKey = _.first(org.orgKeys);  //PLC this is problematic
 
       if(!name){
         throw new RazeeValidationError(context.req.t('A "name" must be specified'), context);
@@ -353,7 +353,7 @@ const channelResolvers = {
       const path = `${org_id.toLowerCase()}-${channel.uuid}-${newVerUuid}`;
       const bucketName = conf.storage.getChannelBucket(channel.data_location);
       const handler = storageFactory(logger).newResourceHandler(path, bucketName, channel.data_location);
-      const ivText = await handler.setDataAndEncrypt(content, orgKey);
+      const ivText = await handler.setDataAndEncrypt(content, orgKey);  //PLC this is where it's dangerous
       const data = handler.serialize();
 
       const kubeOwnerId = await models.User.getKubeOwnerId(context);

--- a/app/apollo/resolvers/channel.js
+++ b/app/apollo/resolvers/channel.js
@@ -23,7 +23,8 @@ const pLimit = require('p-limit');
 const { applyQueryFieldsToChannels, applyQueryFieldsToDeployableVersions } = require('../utils/applyQueryFields');
 const storageFactory = require('./../../storage/storageFactory');
 const yaml = require('js-yaml');
-const { bestOrgKey, getOrgKeyByUuid } = require('../../utils/orgs.js');  //PLC
+const { bestOrgKey } = require('../../utils/orgs');
+const { getDecryptedContent, encryptAndStore } = require('../utils/versionUtils');
 
 const { ACTIONS, TYPES, CHANNEL_VERSION_YAML_MAX_SIZE_LIMIT_MB, CHANNEL_LIMITS, CHANNEL_VERSION_LIMITS } = require('../models/const');
 const { whoIs, validAuth, getAllowedChannels, filterChannelsToAllowed, NotFoundError, RazeeValidationError, BasicRazeeError, RazeeQueryError} = require ('./common');
@@ -135,7 +136,6 @@ const channelResolvers = {
         if (!org) {
           throw new NotFoundError(context.req.t('Could not find the organization with ID {{org_id}}.', {'org_id':org_id}), context);
         }
-        //PLC const orgKey = _.first(org.orgKeys);  //PLC this is problematic
 
         // search channel by channel uuid or channel name
         const channelFilter = channelName ? { name: channelName, org_id } : { uuid: channelUuid, org_id } ;
@@ -175,22 +175,13 @@ const channelResolvers = {
         }
         await applyQueryFieldsToDeployableVersions([ deployableVersionObj ], queryFields, { orgId: org_id }, context);
 
-        const handler = storageFactory(logger).deserialize(deployableVersionObj.content);
-        //PLC deployableVersionObj.content = await handler.getDataAndDecrypt(orgKey, deployableVersionObj.iv);
         try {
-          const orgKey = getOrgKeyByUuid( org, versionObj.desiredOrgKeyUuid || org.orgKeys[0] );
-          deployableVersionObj.content = await handler.getDataAndDecrypt(orgKey.key, deployableVersionObj.iv);
+          const decryptedContentResult = await getDecryptedContent( context, org, deployableVersionObj );
+          deployableVersionObj.content = decryptedContentResult.content;
         }
-        catch( decryptError1 ) {
-          logger.warn(decryptError1, `${queryName} encountered an error when decrypting version '${versionObj.uuid}' with desiredOrgKeyUuid for request ${req_id}: ${decryptError1.message}`);
-          try {
-            const orgKey = getOrgKeyByUuid( org, versionObj.verifiedOrgKeyUuid || org.orgKeys[0] );
-            deployableVersionObj.content = await handler.getDataAndDecrypt(orgKey.key, deployableVersionObj.iv);
-          }
-          catch( decryptError2 ) {
-            logger.error(decryptError2, `${queryName} encountered an error when decrypting version '${versionObj.uuid}' with verifiedOrgKeyUuid for request ${req_id}: ${decryptError2.message}`);
-            throw new RazeeQueryError(context.req.t('Query {{queryName}} error. MessageID: {{req_id}}.', {'queryName':queryName, 'req_id':req_id}), context);
-          }
+        catch( e ) {
+          logger.error({req_id, user: whoIs(me), org_id, channelUuid, versionUuid, channelName, versionName }, `${queryName} encountered an error when decrypting version '${versionObj.uuid}' for request ${req_id}: ${e.message}`);
+          throw new RazeeQueryError(context.req.t('Query {{queryName}} error. MessageID: {{req_id}}.', {'queryName':queryName, 'req_id':req_id}), context);
         }
 
         return deployableVersionObj;
@@ -368,13 +359,7 @@ const channelResolvers = {
       }
 
       const newVerUuid = UUID();
-      const path = `${org_id.toLowerCase()}-${channel.uuid}-${newVerUuid}`;
-      const bucketName = conf.storage.getChannelBucket(channel.data_location);
-      const handler = storageFactory(logger).newResourceHandler(path, bucketName, channel.data_location);
-      const orgKey = bestOrgKey( org ); //PLC
-      const ivText = await handler.setDataAndEncrypt(content, orgKey.key);  //PLC
-      const data = handler.serialize();
-
+      const orgKey = bestOrgKey( org );
       const kubeOwnerId = await models.User.getKubeOwnerId(context);
       const deployableVersionObj = {
         _id: UUID(),
@@ -384,31 +369,31 @@ const channelResolvers = {
         channelName: channel.name,
         name,
         description,
-        content: data,
-        iv: ivText,
         type,
         ownerId: me._id,
         kubeOwnerId,
-        //PLC
         verifiedOrgKeyUuid: orgKey.orgKeyUuid,
         desiredOrgKeyUuid: orgKey.orgKeyUuid,
       };
+      const { data } = await encryptAndStore( context, org, channel, deployableVersionObj, orgKey, content);
+      deployableVersionObj.content = data;
 
       // Note: if failure occurs here, the data has already been stored by storageFactory.
       // A cleanup mechanism is needed.
       const dObj = await models.DeployableVersion.create(deployableVersionObj);
+
+      // Note: if failure occurs here, the data has already been stored by storageFactory and the Version document saved.
+      // A cleanup mechanism is needed, or elimination of the need to update the Channel.
       const versionObj = {
         uuid: deployableVersionObj.uuid,
         name, description,
         created: dObj.created
       };
-
-      // Note: if failure occurs here, the data has already been stored by storageFactory and the Version document saved.
-      // A cleanup mechanism is needed, or elimination of the need to update the Channel.
       await models.Channel.updateOne(
         { org_id, uuid: channel.uuid },
         { $push: { versions: versionObj } }
       );
+
       return {
         success: true,
         versionUuid: versionObj.uuid,

--- a/app/apollo/resolvers/cluster.js
+++ b/app/apollo/resolvers/cluster.js
@@ -22,7 +22,7 @@ const GraphqlFields = require('graphql-fields');
 const _ = require('lodash');
 const { convertStrToTextPropsObj } = require('../utils');
 const { applyQueryFieldsToClusters } = require('../utils/applyQueryFields');
-const { bestOrgKeyValue } = require('../../utils/orgs');
+const { bestOrgKey } = require('../../utils/orgs');
 
 
 const { validateString, validateJson } = require('../utils/directives');
@@ -478,7 +478,7 @@ const clusterResolvers = {
             url += `&args=${arg}`;
           });
         }
-        return { url, orgId: org_id, clusterId: cluster_id, orgKey: bestOrgKeyValue( org ), regState: reg_state, registration };
+        return { url, orgId: org_id, clusterId: cluster_id, orgKey: bestOrgKey( org ).key, regState: reg_state, registration };
       } catch (error) {
         if(error instanceof BasicRazeeError ){
           throw error;

--- a/app/apollo/resolvers/organization.js
+++ b/app/apollo/resolvers/organization.js
@@ -20,13 +20,11 @@ const { v4: UUID } = require('uuid');
 
 const { validateString } = require('../utils/directives');
 
-const { getLegacyOrgKeyObject } = require( `../../utils/orgs.js` ); //PLC
+const { getLegacyOrgKeyObject } = require( '../../utils/orgs.js' );
+const { updateVersionEncryption } = require( '../utils/versionUtils.js' );
 
-//PLC
-const updateVersionEncryption = async (version, orgKey) => {
-  // EMPTY PLACEHOLDER
-  return true;
-};
+// Limit orgKeys to a small number.  In normal usage there should never be more than two or three (previous orgkey, new primary orgkey).
+const ORGKEY_LIMIT = 5;
 
 const unsetPrimaryUnless = async (models, orgId, orgKeyUuid) => {
   const sets = {};
@@ -167,13 +165,15 @@ const organizationResolvers = {
       try {
         const org = await models.Organization.findById(orgId);
         logger.info({ req_id, user: whoIs(me), orgId, name, primary }, `${queryName} org retrieved`);
-        //console.log( `org: ${JSON.stringify(org, null, 2)}` );
+
+        if( (org.orgKeys ? org.orgKeys.length : 0) + (org.orgKeys2 ? org.orgKeys2.length : 0) >= ORGKEY_LIMIT ) {
+          throw new RazeeValidationError(context.req.t('Maximum number of Organization Keys reached: {{number}}', {'number':ORGKEY_LIMIT}), context);
+        }
 
         // Attempt to prevent name duplication
         if( org.orgKeys2 && org.orgKeys2.find( e => { return e.name === name; } ) ) {
           throw new RazeeValidationError(context.req.t('The provided name is already in use: {{name}}', {'name':name}), context);
         }
-        logger.info({ req_id, user: whoIs(me), orgId, name, primary }, `${queryName} OrgKey '${name}' does not  already exist`);
 
         // Define the new OrgKey
         const newOrgKeyUuid = UUID();
@@ -205,13 +205,17 @@ const organizationResolvers = {
             logger.error({ req_id, user: whoIs(me), orgId, name, primary, res, error: error.message }, `${queryName} error removing primary from other OrgKeys, continuing`);
           }
 
-          // PLC Update version encryption to use the new Primary OrgKey
+          /*
+          The OrgKeys (originally just hard coded as the first `orgKeys` element before OrgKey management was enabled) are used to encrypt/decrypt Version content stored in S3 or embedded.
+          When a new Primary OrgKey is identified, existing encrypted data must be re-encrypted so the old OrgKey can be eventually deleted.
+          Only Versions need to be updated as only Versions use encryption when storing/retrieving data.  Resources just use setData/getData methods.
+          */
           const versions = await models.DeployableVersion.find({ org_id: orgId });
           for( const v of versions ) {
             try {
-              const encryptionUpdated = await updateVersionEncryption( v, newOrgKey );
+              const encryptionUpdated = await updateVersionEncryption( context, org, v, newOrgKey );
               if( encryptionUpdated ) {
-                logger.info({ req_id, user: whoIs(me), orgId, name, primary, res }, `${queryName} version encryption updated successfully: ${v.channelUuid}:${v.uuid} / ${v.channelName}:${v.name}`);
+                logger.info({ req_id, user: whoIs(me), orgId, name, primary, res }, `${queryName} version encryption updated successfully: ${v.channelId}:${v.uuid} / ${v.channelName}:${v.name}`);
               }
               else {
                 // log warning but continue
@@ -220,7 +224,7 @@ const organizationResolvers = {
             }
             catch(e) {
               // log error but continue
-              logger.error({ req_id, user: whoIs(me), orgId, name, primary, res, error: error.message }, `${queryName} error updating version content encryption with new primary OrgKey, continuing`);
+              logger.error({ req_id, user: whoIs(me), orgId, name, primary, res, error: e.message }, `${queryName} error updating version content encryption with new primary OrgKey, continuing`);
             }
           }
         }
@@ -234,7 +238,7 @@ const organizationResolvers = {
           throw error;
         }
 
-        logger.error({ req_id, user: whoIs(me), orgId, name, primary, error }, `${queryName} error encountered: ${e.message}`);
+        logger.error({ req_id, user: whoIs(me), orgId, name, primary, error }, `${queryName} error encountered: ${error.message}`);
         throw new RazeeQueryError(context.req.t('Query {{queryName}} error. {{error.message}}', {'queryName':queryName, 'error.message':error.message}), context);
       }
     }, // end createOrgKey
@@ -262,7 +266,7 @@ const organizationResolvers = {
           if( thisOrgKey && thisOrgKey.primary ) {
             // Forbidden
             logger.warn({ req_id, user: whoIs(me), orgId, uuid, forceDeletion }, `${queryName} OrgKey cannot be removed because it is in use (primary)` );
-            if( !forceDeletion ) throw new RazeeForbiddenError( context.req.t( 'Organization key {{id}} cannot be removed or altered because it is in use.', {id: uuid} ), context );
+            if( !forceDeletion ) throw new RazeeForbiddenError( context.req.t( 'Organization key {{id}} cannot be removed or altered because it is the only Primary key.', {id: uuid} ), context );
           }
         }
 
@@ -293,28 +297,19 @@ const organizationResolvers = {
           throw new NotFoundError( context.req.t( 'Could not find the organization key.' ), context );
         }
 
-        //PLC
-        /*
-        // Ensure not removing the first orgKey - temporary restriction as it is used to encrypt deployable versions content before storage
-        if( org.orgKeys[0] == uuid ) {
-          // Forbidden, cannot force!
-          logger.warn({ req_id, user: whoIs(me), orgId, uuid, forceDeletion }, `${queryName} OrgKey cannot be removed because it is in use (encryption)` );
-          throw new RazeeForbiddenError( context.req.t( 'Organization key {{id}} cannot be removed or altered because it is in use.', {id: uuid} ), context );
-        }
-        */
-        // Ensure not removing a potentially in-use OrgKey (for version content encryption)
+        // Ensure not removing a potentially in-use OrgKey (for version content encryption) (cannot force)
         const versionsUsingOrgKey = await models.DeployableVersion.find({ org_id: orgId, $or: [ { verifiedOrgKeyUuid: { $exists: false } }, { desiredOrgKeyUuid: { $exists: false } }, {verifiedOrgKeyUuid: foundOrgKey.orgKeyUuid}, {desiredOrgKeyUuid: foundOrgKey.orgKeyUuid} ] });
         if( versionsUsingOrgKey.length > 0 ) {
           // Forbidden
           logger.warn({ req_id, user: whoIs(me), orgId, uuid, forceDeletion }, `${queryName} OrgKey cannot be removed because it is in use (version encryption)` );
-          if( !forceDeletion ) throw new RazeeForbiddenError( context.req.t( 'Organization key {{id}} cannot be removed or altered because it is in use.', {id: uuid} ), context );
+          throw new RazeeForbiddenError( context.req.t( 'Organization key {{id}} cannot be removed or altered because it is in use for data encryption.  Create a new key before retrying.', {id: uuid} ), context );
         }
 
-        // Ensure not removing the last OrgKey, unless forced
+        // Ensure not removing the last OrgKey (cannot force)
         if( allOrgKeys.length == 1 ) {
           // Forbidden
           logger.warn({ req_id, user: whoIs(me), orgId, uuid, forceDeletion }, `${queryName} OrgKey cannot be removed because it is in use (last one)` );
-          if( !forceDeletion ) throw new RazeeForbiddenError( context.req.t( 'Organization key {{id}} cannot be removed or altered because it is in use.', {id: uuid} ), context );
+          throw new RazeeForbiddenError( context.req.t( 'Organization key {{id}} cannot be removed or altered because it is the last one.', {id: uuid} ), context );
         }
 
         // Ensure not removing an orgKey that was the last one used by at least one managed cluster, unless forced
@@ -323,9 +318,9 @@ const organizationResolvers = {
           lastOrgKeyUuid: uuid,
         } ).lean({ virtuals: true });
         if( clusterUsingOrgKey ) {
-          // Forbidden
+          // Forbidden, but can force (stopped/deleted cluster might never report in again, or update its orgkey)
           logger.warn({ req_id, user: whoIs(me), orgId, uuid, forceDeletion }, `${queryName} OrgKey cannot be removed because it is in use (cluster)` );
-          if( !forceDeletion ) throw new RazeeForbiddenError( context.req.t( 'Organization key {{id}} cannot be removed or altered because it is in use.', {id: uuid} ), context );
+          if( !forceDeletion ) throw new RazeeForbiddenError( context.req.t( 'Organization key {{id}} cannot be removed or altered because it is in use by one or more clusters.', {id: uuid} ), context );
         }
 
         // Remove the OrgKey from both orgKeys and orgKeys2
@@ -334,7 +329,7 @@ const organizationResolvers = {
           orgKeys2: { orgKeyUuid: uuid }
         };
         await models.Organization.updateOne( { _id: orgId }, { $pull: pull } );
-        logger.info({ req_id, user: whoIs(me), orgId, uuid, forceDeletion }, `${queryName} OrgKey removed`);
+        logger.info({ req_id, user: whoIs(me), orgId, uuid, forceDeletion }, `${queryName} OrgKey with value '${foundOrgKey.key}' removed`);
 
         return { success: true };
       }
@@ -395,7 +390,7 @@ const organizationResolvers = {
           if( orgKey.primary && primaryOrgKeys.length < 2 ) {
             // Forbidden
             logger.warn({ req_id, user: whoIs(me), orgId, uuid }, `${queryName} OrgKey cannot be altered because it is in use (primary)` );
-            throw new RazeeForbiddenError( context.req.t( 'Organization key {{id}} cannot be removed or altered because it is in use.', {id: uuid} ), context );
+            throw new RazeeForbiddenError( context.req.t( 'Organization key {{id}} cannot be removed or altered because it is the only Primary key.', {id: uuid} ), context );
           }
         }
 

--- a/app/apollo/utils/versionUtils.js
+++ b/app/apollo/utils/versionUtils.js
@@ -53,7 +53,7 @@ const getDecryptedContent = async ( context, org, version ) => {
 const updateVersionKeys = async ( context, org, version, desiredOrgKeyUuid, verifiedOrgKeyUuid, newData ) => {
   const { models, me, req_id, logger } = context;
   const logContext = { req_id, user: whoIs(me), orgId: org.uuid, version: version.uuid, methodName: 'updateVersionKeys' };
-  logger.info( logContext, `Entry, desiredOrgKeyUuid: ${desiredOrgKeyUuid}, verifiedOrgKeyUuid: ${verifiedOrgKeyUuid}, org._id: ${org._id}, version: ${JSON.stringify(version)}` );
+  logger.info( logContext, `Entry, desiredOrgKeyUuid: ${desiredOrgKeyUuid}, verifiedOrgKeyUuid: ${verifiedOrgKeyUuid}, org._id: ${org._id}, version: ${version.uuid}` );
 
   if( desiredOrgKeyUuid ) {
     const retVal = await models.DeployableVersion.updateOne(

--- a/app/apollo/utils/versionUtils.js
+++ b/app/apollo/utils/versionUtils.js
@@ -1,0 +1,234 @@
+/**
+ * Copyright 2022 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const storageFactory = require('../../storage/storageFactory');
+const { getOrgKeyByUuid } = require('../../utils/orgs.js');
+const { whoIs } = require ('../resolvers/common');
+const conf = require('../../conf.js').conf;
+
+const getDecryptedContent = async ( context, org, version ) => {
+  const { me, req_id, logger } = context;
+  const logContext = { req_id, user: whoIs(me), orgId: org.uuid, version: version.uuid, methodName: 'getDecryptedContent' };
+
+  const handler = storageFactory(logger).deserialize(version.content);
+
+  const retVal = {};
+
+  try {
+    retVal.encryptionOrgKeyUuid = version.desiredOrgKeyUuid || org.orgKeys[0];
+    const orgKey = getOrgKeyByUuid( org, retVal.encryptionOrgKeyUuid );
+    retVal.content = await handler.getDataAndDecrypt(orgKey.key, version.iv);
+  }
+  catch( decryptError1 ) {
+    logger.info(logContext, `encountered an error when decrypting version '${version.uuid}' with desiredOrgKeyUuid for request ${req_id} (will try again with verifiedOrgKeyUuid): ${decryptError1.message}`);
+    try {
+      retVal.encryptionOrgKeyUuid = version.verifiedOrgKeyUuid || org.orgKeys[0];
+      const orgKey = getOrgKeyByUuid( org, retVal.encryptionOrgKeyUuid );
+      retVal.content = await handler.getDataAndDecrypt(orgKey.key, version.iv);
+    }
+    catch( decryptError2 ) {
+      logContext.error = decryptError2.message;
+      logger.error(logContext, `encountered an error when decrypting version '${version.uuid}' with verifiedOrgKeyUuid for request ${req_id}: ${decryptError2.message}`);
+      throw decryptError2;
+    }
+  }
+
+  return retVal;
+};
+
+const updateVersionKeys = async ( context, org, version, desiredOrgKeyUuid, verifiedOrgKeyUuid ) => {
+  const { models, me, req_id, logger } = context;
+  const logContext = { req_id, user: whoIs(me), orgId: org.uuid, version: version.uuid, methodName: 'updateVersionKeys' };
+  logger.info( logContext, `Entry, desiredOrgKeyUuid: ${desiredOrgKeyUuid}, verifiedOrgKeyUuid: ${verifiedOrgKeyUuid}` );
+
+  if( desiredOrgKeyUuid ) {
+    const retVal = await models.DeployableVersion.updateOne(
+      {
+        org_id: org._id,
+        uuid: version.uuid,
+        $and: [
+          {$or: [ { verifiedOrgKeyUuid: { $exists: false } }, { verifiedOrgKeyUuid: version.verifiedOrgKeyUuid } ]},
+          {$or: [ { desiredOrgKeyUuid: { $exists: false } }, { desiredOrgKeyUuid: version.desiredOrgKeyUuid } ]}
+        ]
+      },
+      { $set: { verifiedOrgKeyUuid: verifiedOrgKeyUuid, desiredOrgKeyUuid: desiredOrgKeyUuid } }
+    );
+    return retVal;
+  }
+  else {
+    const retVal = await models.DeployableVersion.updateOne(
+      {
+        org_id: org._id,
+        uuid: version.uuid,
+        $or: [ { verifiedOrgKeyUuid: { $exists: false } }, { verifiedOrgKeyUuid: version.verifiedOrgKeyUuid } ]
+      },
+      { $set: { verifiedOrgKeyUuid: verifiedOrgKeyUuid } }
+    );
+    return retVal;
+  }
+};
+
+/*
+If storing for the first time, 'channel' must be provided so that data location can be determined.
+If overwriting existing data, 'channel' is not used and data location, bucket, path etc are read from the 'version'.
+*/
+const encryptAndStore = async ( context, org, channel, version, orgKey, content ) => {
+  const { me, req_id, logger } = context;
+  const logContext = { req_id, user: whoIs(me), orgId: org.uuid, version: version.uuid, methodName: 'encryptAndStore' };
+
+  /*
+  More concise but fails linting:
+  const path = version?.content?.data?.path || `${org._id.toLowerCase()}-${version.channel_id}-${version.uuid}`;
+  const dataLocation = version?.content?.data?.location || channel?.data_location;
+  const bucketName = version?.content?.data?.bucketName || conf.storage.getChannelBucket(dataLocation);
+  */
+  const path = (version.content && version.content.data && version.content.data.path) ? version.content.data.path : `${org._id.toLowerCase()}-${version.channel_id}-${version.uuid}`;
+  const dataLocation = (version.content && version.content.data && version.content.data.location) ? version.content.data.location : (channel ? channel.data_location : null);
+  const bucketName = (version.content && version.content.data && version.content.data.bucketName) ? version.content.data.bucketName : conf.storage.getChannelBucket(dataLocation);
+  logger.info( logContext, `${(version.content && version.content.data) ? 'create object' : 'overwrite object'}, bucketName: ${bucketName}, path: ${path}` );
+
+  const handler = storageFactory(logger).newResourceHandler(path, bucketName, dataLocation);
+  await handler.setDataAndEncrypt(content, orgKey.key);
+  logger.info( logContext, 'data stored successfully' );
+  const data = handler.serialize();
+  return( {data} );
+};
+
+/*
+Update the Version to use the new orgKey for encryption.
+Each Version tracks which OrgKey is currently used for encryption (verifiedOrgKeyUuid) and which OrgKey it is being re-encrypted with (desiredOrgKeyUuid).
+If execution is terminated during the re-encryption, one of these two will still be valid and ensures that decryption is always possible.
+
+Return true if completely successful
+Return false if:
+  - Unable to update the Version record due to concurrent modification/deletion
+  - Unable to re-encrypt and store the Version content
+Throw error if:
+  - Unable to decrypt current version content
+  - Unable to communicate with the database to update the Version record
+*/
+const updateVersionEncryption = async (context, org, version, newOrgKey) => {
+  const { me, req_id, logger } = context;
+  const logContext = { req_id, user: whoIs(me), orgId: org.uuid, version: version.uuid, orgKey: newOrgKey.orgKeyUuid, methodName: 'updateVersionEncryption' };
+  logger.info( logContext, 'Entry' );
+
+  let encryptionOrgKeyUuid, content;
+  try {
+    const decryptResult = await getDecryptedContent( context, org, version );  // This func tries `desiredOrgKeyUuid` first, falls back to `verifiedOrgKeyUuid`, then fails if neither work.
+    encryptionOrgKeyUuid = decryptResult.encryptionOrgKeyUuid;
+    content = decryptResult.content;
+  }
+  catch( e ) {
+    // It could not be retrieved or could not be decrypted, something has gone wrong!
+    // E.g. someone/something force-deleting an OrgKey such that data encrypted with it cannot be retrieved.
+    logContext.error = e.message;
+    logger.error( logContext, 'Unable to retrieve existing Version content' );
+    throw( e );
+  }
+  logger.info( logContext, `Version contents decrypted, encryptionOrgKeyUuid: ${encryptionOrgKeyUuid}` );
+
+  if( version.desiredOrgKeyUuid != newOrgKey.orgKeyUuid || version.verifiedOrgKeyUuid != newOrgKey.orgKeyUuid ) {
+    // Version is not using the new OrgKey as BOTH `verifiedOrgKeyUuid` and `desiredOrgKeyUuid`.
+    // Either way, the Version needs to be updated to set working OrgKey as `verifiedOrgKeyUuid` and the new OrgKey as `desiredOrgKeyUuid`.
+    try {
+      const result = await updateVersionKeys( context, org, version, newOrgKey.orgKeyUuid, encryptionOrgKeyUuid );
+      logger.info( logContext, `Version key update result: ${JSON.stringify(result)}` );
+      if( result.nModified != 1 ) {
+        // Version update did not occur because another process was updating the Version record in parallel (possibly even deleting it).
+        // Re-encryption did not occur but the Version still has the OrgKey that is known to decrypt successfully in either `verifiedOrgKeyUuid` or `desiredOrgKeyUuid`
+        // Additional future calls to this function will attempt to rectify this again, but Version content retrieval will continue to work in the mean time.
+        logger.warn( logContext, `Simultaneous updates to Version '${version.uuid}' prevented updates to verifiedOrgKeyUuid and desiredOrgKeyUuid, unable to update encryption.` );
+        return( false );
+      }
+    }
+    catch( e ) {
+      // Error communicating with database, throw
+      logContext.error = e.message;
+      logger.error( logContext, 'Error during database record update' );
+      throw e;
+    }
+    logger.info( logContext, 'Version keys update started' );
+    // After updating the Version record with `verifiedOrgKeyUuid` and `desiredOrgKeyUuid`, continue and re-encrypt with new OrgKey if needed.
+  }
+
+  if( encryptionOrgKeyUuid == newOrgKey.orgKeyUuid ) {
+    // Version is already able to decrypt with the Primary OrgKey
+    // Version uses Primary OrgKey as `verifiedOrgKeyUuid` (if not already set, was set above)
+    // Version uses Primary OrgKey as `desiredOrgKeyUuid` (if not already set, was set above)
+    // No re-encryption needed
+    logger.info( logContext, 'Encryption is already up to date.' );
+    return( true );
+  }
+  else {
+    // Version is not able to decrypt with the Primary OrgKey (though the primary is now set as the `desiredOrgKeyUuid`, the _actual_ working OrgKey is set as `verifiedOrgKeyUuid`)
+    // Re-encryption needed
+    try {
+      // The Version contains all the data storage info needed (bucket name, data location, path), so channel is passed as 'null' for re-encryption.
+      // The Version's `content` is not changed by re-encryption, so `encryptAndStore` return value is not used.
+      await encryptAndStore( context, org, null, version, newOrgKey, content );
+    }
+    catch( encryptErr ) {
+      // Re-encryption did not occur but the Version still has the OrgKey that is known to decrypt successfully in `verifiedOrgKeyUuid`.
+      // Additional future calls to this function will attempt to rectify this again, but Version content retrieval will continue to work in the mean time.
+      return( false );
+    }
+    logger.info( logContext, 'Version content re-encrypted' );
+
+    /*
+    Before 'updateVersionEncryption' was introduced, the iv (initialization vector) bytes would be stored separately from the encrypted data, in the db record.
+    This is problematic for re-encryption as any data reads _between_ storing the re-encrypted data and storing the iv in the db record will use incorrect iv and result in garbled response (not an exception).
+    If the code happens to _exit for any reason_ between storing the encrypted data and updating the db record (e.g. crash, pod eviction, etc), the iv is permanently lost and the data permanently garbled.
+    Initial version creation doesn't have this problem only because it writes the encrypted data first and then creates the Version record with the iv -- the data cannot be read before the Version record is created.
+
+    To address this problem and allow re-encrypting the data, all new encrypted data and re-encrypted data will store the iv along with the encrypted data, separated by a single char delimiter.
+    - If the retrieved data length is a multiple of 128 bits, it is just the encrypted data and iv from the db record must be used to decrypt.
+    - If the retrieved data length has 25 extra bytes on it, the extra bytes are the iv used to decrypt.
+
+    Alternative solutions considered include:
+    - All new encryption / re-encryptionUse a different algorithm that doesn't rely on 'iv' text, such as 'AES'.  If unable to decrypt with old algorithm, fall back to 'AES'.
+    - New data storage to actually *de*-encrypt and store plaintext.  If unable to decrypt with old algorithm, fall back to returning plaintext.
+    */
+
+    // After re-encrypting, update the Version to reflect the new `verifiedOrgKeyUuid`
+    try {
+      const result = await updateVersionKeys( context, org, version, null, newOrgKey.orgKeyUuid );
+      if( result.nModified != 1 ) {
+        // Version update did not occur because another process was updating the Version record in parallel (possibly even deleting it).
+        // Re-encryption using the Primary DID occur here, the other process did the same (or is deleting the Version).
+        // The other process already updated the Version's `verifiedOrgKeyUuid`, so the fact that this process could not update it can be ignored (especially if the Version is being deleted).
+        // Log a warning, but continue.
+        logger.warn( logContext, `Simultaneous updates to Version '${version.uuid}' prevented updates to verifiedOrgKeyUuid, continuing.` );
+      }
+      logger.info( logContext, 'Version keys update finished' );
+    }
+    catch( e ) {
+      // Error communicating with database, throw
+      logContext.error = e.message;
+      logger.error( logContext, 'Error during database record update' );
+      throw e;
+    }
+
+    // Version updates and re-encryption successful (or no-op)
+    logger.info( logContext, 'Version updates and re-encryption successful (or no-op)' );
+    return( true );
+  }
+};
+
+module.exports = {
+  getDecryptedContent,
+  encryptAndStore,
+  updateVersionEncryption,
+};

--- a/app/routes/v1/systemSubscriptions.js
+++ b/app/routes/v1/systemSubscriptions.js
@@ -17,7 +17,7 @@
 const express = require('express');
 const router = express.Router();
 const asyncHandler = require('express-async-handler');
-const { getOrg, bestOrgKeyValue } = require('../../utils/orgs');
+const { getOrg, bestOrgKey } = require('../../utils/orgs');
 
 /*
 Serves a System Subscription that regenerates the `razee-identity` secret with the 'best' OrgKey value.
@@ -32,7 +32,7 @@ metadata:
     razee/watch-resource: lite
     addonmanager.kubernetes.io/mode: Reconcile
 data:
-  RAZEE_ORG_KEY: ${Buffer.from( bestOrgKeyValue( req.org ) ).toString('base64')}
+  RAZEE_ORG_KEY: ${Buffer.from( bestOrgKey( req.org ).key ).toString('base64')}
 type: Opaque
 `;
 

--- a/app/storage/s3ResourceHandler.js
+++ b/app/storage/s3ResourceHandler.js
@@ -19,6 +19,7 @@
 const conf = require('./../conf.js').conf;
 const S3ClientClass = require('./s3NewClient');
 const cipher = require('./cipher');
+const iv_delim = ' ';
 
 class S3ResourceHandler {
 
@@ -53,11 +54,12 @@ class S3ResourceHandler {
   }
 
   async setDataAndEncrypt(stringOrBuffer, key) {
-    this.logInfo(`Uploading object ${this.bucketName}:${this.resourceKey} ...`);
+    this.logInfo(`Uploading encrypted object ${this.bucketName}:${this.resourceKey} ...`);
     const { encryptedBuffer, ivText } = cipher.encrypt(stringOrBuffer, key);
-    const result = await this.s3NewClient.upload(this.bucketName, this.resourceKey, encryptedBuffer);
-    this.logInfo(`Uploaded object to ${result.Location}`);
-    return ivText;
+    const ivBuffer = Buffer.from( ivText+iv_delim, 'utf8' );
+    const s_combinedBuffer = Buffer.concat( [ivBuffer, encryptedBuffer] );
+    const result = await this.s3NewClient.upload(this.bucketName, this.resourceKey, s_combinedBuffer);
+    this.logInfo(`Uploaded encrypted object to ${result.Location}`);
   }
 
   async setData(stringOrBuffer) {
@@ -66,11 +68,22 @@ class S3ResourceHandler {
     this.logInfo(`Uploaded object to ${result.Location}`);
   }
 
+  // If data embeds iv, ignore passed iv (passed iv only for legacy data)
   async getDataAndDecrypt(key, iv) {
     this.logInfo(`Downloading object ${this.bucketName}:${this.resourceKey} ...`);
     const response = await this.s3NewClient.getObject(this.bucketName, this.resourceKey);
     const encryptedBuffer = Buffer.from(response.Body);
-    return cipher.decryptBuffer(encryptedBuffer, key, iv); // utf-8 text
+
+    const delimIdx = encryptedBuffer.indexOf( iv_delim, 0, 'utf8' );
+    // If iv is embedded, first 24 bytes are the embedded iv.  The rest of the buffer is the delimiter and the encrypted content, which will be multiples of 8 bytes.
+    if( delimIdx == 24 && encryptedBuffer.length % 8 == iv_delim.length ) {
+      this.logInfo( `retrieved buffer (len: ${encryptedBuffer.length}) embeds iv` );
+      let s_iv = encryptedBuffer.subarray(0,delimIdx).toString('utf8');
+      const s_encryptedBuffer = encryptedBuffer.subarray( delimIdx + iv_delim.length );
+      return cipher.decryptBuffer(s_encryptedBuffer, key, s_iv); // utf-8 text
+    }
+    this.logInfo( `retrieved buffer (len: ${encryptedBuffer.length}) does not embed iv` );
+    return cipher.decryptBuffer(encryptedBuffer, key, iv);
   }
 
   async getData() {

--- a/app/utils/orgs.js
+++ b/app/utils/orgs.js
@@ -68,7 +68,6 @@ const decryptOrgData = (orgKey, data) => {
   return tokenCrypt.decrypt(data, orgKey);
 };
 
-//PLC
 /*
 Best OrgKey value is:
 - First found OrgKeys2 key marked as Primary

--- a/app/utils/orgs.tests.js
+++ b/app/utils/orgs.tests.js
@@ -19,7 +19,7 @@ const mongodb = require('mongo-mock');
 const httpMocks = require('node-mocks-http');
 const { log } = require('../log');
 
-const { getOrg, verifyAdminOrgKey, bestOrgKeyValue } = require('./orgs');
+const { getOrg, verifyAdminOrgKey, bestOrgKey } = require('./orgs');
 
 let db = {};
 
@@ -206,7 +206,7 @@ describe('utils', () => {
         ]
       };
 
-      const bestOrgKey = bestOrgKeyValue( testOrg );
+      const bestOrgKey = bestOrgKey( testOrg ).key;
       assert.equal(bestOrgKey, 'bestKey');
     });
   });

--- a/app/utils/orgs.tests.js
+++ b/app/utils/orgs.tests.js
@@ -206,8 +206,8 @@ describe('utils', () => {
         ]
       };
 
-      const bestOrgKey = bestOrgKey( testOrg ).key;
-      assert.equal(bestOrgKey, 'bestKey');
+      const orgKey = bestOrgKey( testOrg ).key;
+      assert.equal(orgKey, 'bestKey');
     });
   });
 });

--- a/local-dev/api/apiChannelVersionGet.sh
+++ b/local-dev/api/apiChannelVersionGet.sh
@@ -6,7 +6,7 @@ RAZEE_ORG_KEY=${1:-${RAZEE_ORG_KEY:-pOrgKey}}
 
 AUTH_HEADER="no-auth-available: asdf"
 
-RAZEE_URL=${RAZEE_URL:-http://localhost:3333/api/v1/channels/dummychannel/dummyversion}
+RAZEE_URL=${RAZEE_URL:-http://localhost:3333/api/v1/channels/${RAZEE_CONFIG_NAME:-pConfigName}/${RAZEE_VER_UUID:-dummyversionuuid}}
 
 echo "GET to ${RAZEE_URL}"
 curl \

--- a/local-dev/api/configCreateByName.sh
+++ b/local-dev/api/configCreateByName.sh
@@ -3,10 +3,10 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 if [ "$0" = "$BASH_SOURCE" ]; then
-  echo "$0 can be sourced to automatically set the RAZEE_CONFIG_UUID variable"
+  echo "$0 can be sourced to automatically set the RAZEE_CONFIG_UUID and RAZEE_CONFIG_NAME variables"
 fi
 
-RAZEE_CONFIG_NAME=${1:-pConfigName}
+export RAZEE_CONFIG_NAME=${1:-pConfigName}
 RAZEE_CONFIG_DATALOCATION=${2:-pDataLocation}
 RAZEE_ORG_ID=${3:-${RAZEE_ORG_ID:-pOrgId}}
 
@@ -15,6 +15,7 @@ RAZEE_VARIABLES='{"name":"'"${RAZEE_CONFIG_NAME}"'","data_location":"'"${RAZEE_C
 
 echo "" && echo "CREATE config by name"
 unset RAZEE_CONFIG_UUID
+unset RAZEE_CONFIG_NAME
 RESPONSE=$(${SCRIPT_DIR}/graphqlPost.sh "${RAZEE_QUERY}" "${RAZEE_VARIABLES}")
 echo "Result: $?"
 echo "Response:"
@@ -24,6 +25,8 @@ export RAZEE_CONFIG_UUID=$(echo ${RESPONSE} | jq -r '.data.addChannel.uuid')
 if [ "${RAZEE_CONFIG_UUID}" = "null" ]; then
   echo "Unable to determine RAZEE_CONFIG_UUID"
   unset RAZEE_CONFIG_UUID
+  unset RAZEE_CONFIG_NAME
 else
   echo "RAZEE_CONFIG_UUID: ${RAZEE_CONFIG_UUID}"
+  echo "RAZEE_CONFIG_NAME: ${RAZEE_CONFIG_NAME}"
 fi

--- a/local-dev/api/configCreateByNameNoDataLocation.sh
+++ b/local-dev/api/configCreateByNameNoDataLocation.sh
@@ -3,10 +3,10 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 if [ "$0" = "$BASH_SOURCE" ]; then
-  echo "$0 can be sourced to automatically set the RAZEE_CONFIG_UUID variable"
+  echo "$0 can be sourced to automatically set the RAZEE_CONFIG_UUID and RAZEE_CONFIG_NAME variables"
 fi
 
-RAZEE_CONFIG_NAME=${1:-pConfigName}
+export RAZEE_CONFIG_NAME=${1:-pConfigName}
 RAZEE_ORG_ID=${2:-${RAZEE_ORG_ID:-pOrgId}}
 
 RAZEE_QUERY='mutation ($orgId: String!, $name: String!, $data_location: String) { addChannel(orgId: $orgId, name: $name, data_location: $data_location) { uuid } }'
@@ -14,6 +14,7 @@ RAZEE_VARIABLES='{"name":"'"${RAZEE_CONFIG_NAME}"'","orgId":"'"${RAZEE_ORG_ID}"'
 
 echo "" && echo "CREATE config by name"
 unset RAZEE_CONFIG_UUID
+unset RAZEE_CONFIG_NAME
 RESPONSE=$(${SCRIPT_DIR}/graphqlPost.sh "${RAZEE_QUERY}" "${RAZEE_VARIABLES}")
 echo "Result: $?"
 echo "Response:"
@@ -23,6 +24,8 @@ export RAZEE_CONFIG_UUID=$(echo ${RESPONSE} | jq -r '.data.addChannel.uuid')
 if [ "${RAZEE_CONFIG_UUID}" = "null" ]; then
   echo "Unable to determine RAZEE_CONFIG_UUID"
   unset RAZEE_CONFIG_UUID
+  unset RAZEE_CONFIG_NAME
 else
   echo "RAZEE_CONFIG_UUID: ${RAZEE_CONFIG_UUID}"
+  echo "RAZEE_CONFIG_NAME: ${RAZEE_CONFIG_NAME}"
 fi

--- a/local-dev/api/verCreateByName.sh
+++ b/local-dev/api/verCreateByName.sh
@@ -12,7 +12,8 @@ RAZEE_CONFIG_UUID=${3:-${RAZEE_CONFIG_UUID:-pConfigUuid}}
 RAZEE_VER_DESCR=${4:-pVerDescription}
 
 RAZEE_QUERY='mutation($orgId: String!, $channelUuid: String!, $name: String!, $type: String!, $content: String!, $description: String) { addChannelVersion( orgId: $orgId channelUuid: $channelUuid name: $name type: $type content: $content description: $description ) { versionUuid success } }'
-CONTENT="{ \\\"apiVersion\\\": \\\"v1\\\",\\\"kind\\\": \\\"ConfigMap\\\",\\\"name\\\": \\\"${RAZEE_VER_NAME}-configmap\\\",\\\"namespace\\\": \\\"default\\\",\\\"data\\\": {\\\"DUMMYKEY\\\": \\\"DUMMYVAL\\\"}}"
+RANDOMSTRING=$(head /dev/random | LC_ALL=C tr -cd 'A-Za-z0-9' | head -c 10000)
+CONTENT="{ \\\"apiVersion\\\": \\\"v1\\\",\\\"kind\\\": \\\"ConfigMap\\\",\\\"name\\\": \\\"${RAZEE_VER_NAME}-configmap\\\",\\\"namespace\\\": \\\"default\\\",\\\"data\\\": {\\\"DUMMYKEY\\\": \\\"${RANDOMSTRING}\\\"}}"
 RAZEE_VARIABLES='{"name":"'"${RAZEE_VER_NAME}"'","orgId":"'"${RAZEE_ORG_ID}"'","channelUuid":"'"${RAZEE_CONFIG_UUID}"'","type":"application/yaml","content":"'"${CONTENT}"'","description":"'"${RAZEE_VER_DESCR}"'"}'
 
 echo "" && echo "CREATE version by name"

--- a/local-dev/api/verCreateMany.sh
+++ b/local-dev/api/verCreateMany.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+for i in {1..1000}
+do
+   ./verCreateByName.sh v${i}
+done


### PR DESCRIPTION
Summary:
OrgKeys are used to encrypt content before storage for Versions.  Razeedash-api cannot delete OrgKeys that are used for this encryption, else the content would become lost.  To be able to create new OrgKeys and delete old ones (i.e. 'rotation'), it is necessary to re-encrypt existing content with new OrgKeys.

Re-encryption is done asynchronously, i.e. without waiting for it to complete, when:
- a new Primary OrgKey is created
- an attempt is made to delete an existing OrgKey that is still used for encryption
  - The deletion will be blocked, but re-encryption started in the background.  The error message will inform the user that re-encryption is occurring and to try the deletion again later.

The re-encryption also continually checks for the best OrgKey to use, so that it can halt if it finds that the OrgKey has changed _again_ before the re-encryption completes.  The implementation prevents repeated retries from increasing load, and prevents parallel re-encryption on separate replicas from causing problems.  If the re-encryption fails for any reason it will be logged, but as it is happening in the background the user will not be immediately informed.  However retrying re-encryption on one of the above triggers will allow it to eventually complete.

Re-encryption stores both the verified key and the desired key on the Version DB record, and uses a three step process to update the Version and the data, to ensure that the encrypted data is never lost due to unexpected exit in the middle of re-encryption:
1. The Version record in the DB is updated with both the current (verified to work) key and the new key
2. The data is re-encrypted and stored
3. The Version record in the DB is updated with the new key used for re-encryption

Even if the runtime exits between 1 and 2 or between 2 and 3, at least one of the two keys will still be able to decrypt the data.  The decryption simply tries the 'desired' key first and then falls back to the 'verified' key if it fails.