### PR TITLE
log db close on shutdown

### DIFF
--- a/app/apollo/index.js
+++ b/app/apollo/index.js
@@ -211,8 +211,11 @@ const createSubscriptionServer = (httpServer, apolloServer, schema) => {
 
 
 const stop = async (apollo) => {
-  await apollo.db.connection.close();
-  await apollo.server.stop();
+  console.log('🏄 Closing database connection');
+  await apollo.db.connection.close( true ); // Use 'true' to force close and prevent timeout during unit tests
+  console.log('🏄 Stopping apollo server');
+  await apollo.server.stop(); // stopgGracePeriodMillis defaults to 10 seconds
+  console.log('🏄 Closing httpserver.');
   await apollo.httpServer.close(() => {
     console.log('🏄 Apollo Server closed.');
   });

--- a/app/apollo/index.js
+++ b/app/apollo/index.js
@@ -213,9 +213,18 @@ const createSubscriptionServer = (httpServer, apolloServer, schema) => {
 const stop = async (apollo) => {
   try {
     let t;
-    console.log( `🚣 Disconnecting database, time: ${Date.now()}` );
+    console.log( `🚣 Stopping, time: ${Date.now()}` );
     console.log( `connection.readyState: ${apollo.db.connection.readyState}` );
+    console.log( `connections: ${apollo.db.connections.length}` );
     t = Date.now();
+    try {
+      console.log( `🚣 Closing default connection, time: ${Date.now()}` );
+      await apollo.db.connection.close(true);
+    }
+    catch(e){
+      console.log( `🏊 Error closing default connection, time: ${Date.now()}, error: ${e.message}` );
+    }
+    console.log( `🚣 Disconnecting database, time: ${Date.now()}` );
     await apollo.db.disconnect();
     console.log( `final connection.readyState: ${apollo.db.connection.readyState}` );
     console.log( `Database disconnected in ${Date.now()-t} ms, time: ${Date.now()}` );

--- a/app/apollo/index.js
+++ b/app/apollo/index.js
@@ -213,27 +213,27 @@ const createSubscriptionServer = (httpServer, apolloServer, schema) => {
 const stop = async (apollo) => {
   try {
     let t;
-    console.log( '🚣 Disconnecting database' );
+    console.log( `🚣 Disconnecting database, time: ${Date.now()}` );
     console.log( `connection.readyState: ${apollo.db.connection.readyState}` );
     t = Date.now();
     await apollo.db.disconnect();
     console.log( `final connection.readyState: ${apollo.db.connection.readyState}` );
-    console.log( `Database disconnected in ${Date.now()-t} ms` );
+    console.log( `Database disconnected in ${Date.now()-t} ms, time: ${Date.now()}` );
 
     console.log( '🚣 Stopping apollo server' );
     t = Date.now();
     await apollo.server.stop(); // stopgGracePeriodMillis defaults to 10 seconds
-    console.log( `Apollo server stopped in ${Date.now()-t} ms` );
+    console.log( `Apollo server stopped in ${Date.now()-t} ms, time: ${Date.now()}` );
 
     console.log('🚣 Closing httpserver.');
     t = Date.now();
     await apollo.httpServer.close(() => {
-      console.log('🏄 Apollo Server closed.');
+      console.log( `🏄 Apollo Server closed, time: ${Date.now()}` );
     });
-    console.log( `Apollo httpServer closed in ${Date.now()-t} ms` );
+    console.log( `Apollo httpServer closed in ${Date.now()-t} ms, time: ${Date.now()}` );
   }
   catch( e ) {
-    console.log( `🏊 Error during stop: ${e.message}` );
+    console.log( `🏊 Error during stop: ${e.message}, time: ${Date.now()}` );
     throw e;
   }
 };

--- a/app/apollo/models/index.js
+++ b/app/apollo/models/index.js
@@ -57,9 +57,24 @@ const connectDb = async mongoUrl => {
     mongooseOptions['tlsCAFile'] = mongoConf.mongo.cert;
   }
 
+  //PLC
+  mongoose.set('bufferCommands', false);
+
   await mongoose.connect(url, {
     ...mongooseOptions,
   });
+
+  //PLC
+  await User.createCollection();
+  await Resource.createCollection();
+  await Cluster.createCollection();
+  await Organization.createCollection();
+  await Channel.createCollection();
+  await Subscription.createCollection();
+  await ServiceSubscription.createCollection();
+  await DeployableVersion.createCollection();
+  await ResourceYamlHist.createCollection();
+  await Group.createCollection();
 
   return mongoose;
 };

--- a/app/apollo/models/index.js
+++ b/app/apollo/models/index.js
@@ -57,24 +57,9 @@ const connectDb = async mongoUrl => {
     mongooseOptions['tlsCAFile'] = mongoConf.mongo.cert;
   }
 
-  //PLC
-  mongoose.set('bufferCommands', false);
-
   await mongoose.connect(url, {
     ...mongooseOptions,
   });
-
-  //PLC
-  await User.createCollection();
-  await Resource.createCollection();
-  await Cluster.createCollection();
-  await Organization.createCollection();
-  await Channel.createCollection();
-  await Subscription.createCollection();
-  await ServiceSubscription.createCollection();
-  await DeployableVersion.createCollection();
-  await ResourceYamlHist.createCollection();
-  await Group.createCollection();
 
   return mongoose;
 };

--- a/app/apollo/models/index.js
+++ b/app/apollo/models/index.js
@@ -42,12 +42,14 @@ const connectDb = async mongoUrl => {
       autoIndex: false,
       connectTimeoutMS: 30000,
       socketTimeoutMS: 10000,
+      minPoolSize: 15,
     };
   } else {
     mongooseOptions = {
       autoIndex: true,
       connectTimeoutMS: 30000,
       socketTimeoutMS: 10000,
+      minPoolSize: 15,
     };
   }
 
@@ -58,7 +60,8 @@ const connectDb = async mongoUrl => {
   await mongoose.connect(url, {
     ...mongooseOptions,
   });
-  return {connection: mongoose.connection};
+
+  return mongoose;
 };
 
 const models = {

--- a/app/apollo/resolvers/subscription.js
+++ b/app/apollo/resolvers/subscription.js
@@ -537,7 +537,7 @@ const subscriptionResolvers = {
         };
         await models.Subscription.updateOne({ uuid, org_id }, { $set: sets });
 
-        pubSub.channelSubChangedFunc({org_id: org_id}, context);
+        pubSub.channelSubChangedFunc({org_id}, context);
 
         return {
           uuid,

--- a/app/apollo/test/channel.spec.js
+++ b/app/apollo/test/channel.spec.js
@@ -237,6 +237,7 @@ const createSubscriptions = async () => {
 
 describe('channel graphql test suite', () => {
   before(async () => {
+    console.log( `channel.spec.js before entry, time: ${Date.now()}` );
     process.env.NODE_ENV = 'test';
     mongoServer = new MongoMemoryServer( { binary: { version: '4.2.17' } } );
     await mongoServer.start();
@@ -265,6 +266,7 @@ describe('channel graphql test suite', () => {
   after(async () => {
     await myApollo.stop(myApollo);
     await mongoServer.stop();
+    console.log( `channel.spec.js after exit, time: ${Date.now()}` );
   }); // after
 
   it('get channels', async () => {

--- a/app/apollo/test/channel.spec.js
+++ b/app/apollo/test/channel.spec.js
@@ -237,7 +237,6 @@ const createSubscriptions = async () => {
 
 describe('channel graphql test suite', () => {
   before(async () => {
-    console.log( `channel.spec.js before entry, time: ${Date.now()}` );
     process.env.NODE_ENV = 'test';
     mongoServer = new MongoMemoryServer( { binary: { version: '4.2.17' } } );
     await mongoServer.start();
@@ -266,7 +265,6 @@ describe('channel graphql test suite', () => {
   after(async () => {
     await myApollo.stop(myApollo);
     await mongoServer.stop();
-    console.log( `channel.spec.js after exit, time: ${Date.now()}` );
   }); // after
 
   it('get channels', async () => {

--- a/app/apollo/test/subscriptions.spec.js
+++ b/app/apollo/test/subscriptions.spec.js
@@ -37,9 +37,6 @@ const rbacSync = require('../utils/rbacSync.js');
 
 const { GraphqlPubSub } = require('../subscription');
 
-//const why = require('why-is-node-running');
-
-
 let mongoServer;
 let myApollo;
 
@@ -395,13 +392,15 @@ const sleep = async ( ms ) => {
 describe('subscription graphql test suite', () => {
 
   before(async () => {
+    console.log( 'subscription.spec.js before entry' );
+
     process.env.NODE_ENV = 'test';
     rbacSync.testMode(true); // Must be set to trigger/test RBAC Sync
 
     mongoServer = new MongoMemoryServer( { binary: { version: '4.2.17' } } );
     await mongoServer.start();
     const mongoUrl = mongoServer.getUri();
-    console.log(`    cluster.js in memory test mongodb url is ${mongoUrl}`);
+    console.log(`subscriptions.spec.js in memory test mongodb url is ${mongoUrl}`);
 
     myApollo = await apollo({
       mongo_url: mongoUrl,
@@ -423,15 +422,15 @@ describe('subscription graphql test suite', () => {
     //await getPresetOrgs();
     //await getPresetUsers();
     await getPresetClusters();
+    console.log( 'subscription.spec.js before exit' );
   }); // before
 
   after(async () => {
+    console.log( 'subscription.spec.js after entry' );
     await myApollo.stop(myApollo);
     GraphqlPubSub.deleteInstance();
     await mongoServer.stop();
-    // setTimeout(function() {
-    //  why(); // logs out active handles that are keeping node running
-    // }, 5000);
+    console.log( 'subscription.spec.js after exit' );
   }); // after
 
   it('get subscriptions', async () => {

--- a/app/apollo/test/subscriptions.spec.js
+++ b/app/apollo/test/subscriptions.spec.js
@@ -492,7 +492,6 @@ describe('subscription graphql test suite', () => {
     }
   });
 
-  /*
   it('get subscription by subscription uuid', async () => {
     try {
       const result = await subscriptionApi.subscription(token01, {
@@ -593,6 +592,7 @@ describe('subscription graphql test suite', () => {
     }
   });
 
+  /*
   it('add a subscription', async () => {
     try {
       const addSubscription1 = await subscriptionApi.addSubscription(adminToken, {

--- a/app/apollo/test/subscriptions.spec.js
+++ b/app/apollo/test/subscriptions.spec.js
@@ -492,6 +492,7 @@ describe('subscription graphql test suite', () => {
     }
   });
 
+  /*
   it('get subscription by subscription uuid', async () => {
     try {
       const result = await subscriptionApi.subscription(token01, {
@@ -768,4 +769,5 @@ describe('subscription graphql test suite', () => {
       throw error;
     }
   });
+  */
 });

--- a/app/apollo/test/subscriptions.spec.js
+++ b/app/apollo/test/subscriptions.spec.js
@@ -692,6 +692,16 @@ describe('subscription graphql test suite', () => {
       expect(result4.data.data.subscription.custom.forEnv).to.equal('new');
       expect(result4.data.data.subscription.custom.forType).to.equal('new');
 
+      //PLC TEST, get the updated subscription
+      const {
+        data: {
+          data: { subscription },
+        },
+      } = await subscriptionApi.subscription(adminToken, {
+        orgId: org01._id,
+        uuid: subscription_02_uuid,
+      });
+      console.log( `edit subscription completed the query that causes problem in 'set a sub' test, time: ${Date.now()}` );
     } catch (error) {
       if (error.response) {
         console.error('error encountered:  ', error.response.data);

--- a/app/apollo/test/subscriptions.spec.js
+++ b/app/apollo/test/subscriptions.spec.js
@@ -592,7 +592,6 @@ describe('subscription graphql test suite', () => {
     }
   });
 
-  /*
   it('add a subscription', async () => {
     try {
       const addSubscription1 = await subscriptionApi.addSubscription(adminToken, {
@@ -636,6 +635,7 @@ describe('subscription graphql test suite', () => {
     }
   });
 
+  /*
   it('edit a subscription', async () => {
     try {
       //step1, edit the subscription
@@ -735,6 +735,7 @@ describe('subscription graphql test suite', () => {
       throw error;
     }
   });
+  */
 
   it('remove a subscription', async () => {
     try {
@@ -769,5 +770,4 @@ describe('subscription graphql test suite', () => {
       throw error;
     }
   });
-  */
 });

--- a/app/apollo/test/subscriptions.spec.js
+++ b/app/apollo/test/subscriptions.spec.js
@@ -392,7 +392,7 @@ const sleep = async ( ms ) => {
 describe('subscription graphql test suite', () => {
 
   before(async () => {
-    console.log( 'subscription.spec.js before entry' );
+    console.log( `subscription.spec.js before entry, time: ${Date.now()}` );
 
     process.env.NODE_ENV = 'test';
     rbacSync.testMode(true); // Must be set to trigger/test RBAC Sync
@@ -422,15 +422,15 @@ describe('subscription graphql test suite', () => {
     //await getPresetOrgs();
     //await getPresetUsers();
     await getPresetClusters();
-    console.log( 'subscription.spec.js before exit' );
+    console.log( `subscription.spec.js before exit, time: ${Date.now()}` );
   }); // before
 
   after(async () => {
-    console.log( 'subscription.spec.js after entry' );
+    console.log( `subscription.spec.js after entry, time: ${Date.now()}` );
     await myApollo.stop(myApollo);
     GraphqlPubSub.deleteInstance();
     await mongoServer.stop();
-    console.log( 'subscription.spec.js after exit' );
+    console.log( `subscription.spec.js after exit, time: ${Date.now()}` );
   }); // after
 
   it('get subscriptions', async () => {
@@ -700,8 +700,9 @@ describe('subscription graphql test suite', () => {
     }
   });
 
+  //PLC dev note: if this test executes, the db will not disconnect :-( -- apparently either the setSubscription *or* the subscription (get) or both will trigger the problem.
   it('set a subscription configurationVersion', async () => {
-    console.log( 'test setSubscription entry' );
+    console.log( `test setSubscription entry, time: ${Date.now()}` );
     try {
       //step1, edit the subscription's configurationVerision
       const {
@@ -715,7 +716,7 @@ describe('subscription graphql test suite', () => {
       });
       expect(setSubscription.uuid).to.be.an('string');
       expect(setSubscription.success).to.equal(true);
-      /*PLC dev note: if this test executes, the db will not disconnect :-(
+      /*
       //step2, get the updated subscription
       const {
         data: {
@@ -727,19 +728,20 @@ describe('subscription graphql test suite', () => {
       });
       expect(subscription.versionUuid).to.equal(channelVersion_01_uuid);
       */
-      console.log( 'test setSubscription exit' );
+      console.log( `test setSubscription exit, time: ${Date.now()}` );
     } catch (error) {
       if (error.response) {
         console.error('error encountered:  ', error.response.data);
       } else {
         console.error('error encountered:  ', error);
       }
-      console.log( 'test setSubscription error' );
+      console.log( `test setSubscription error, time: ${Date.now()}` );
       throw error;
     }
   });
 
   it('remove a subscription', async () => {
+    console.log( `test remove a subscription entry, time: ${Date.now()}` );
     try {
       //step1, remove the subscription
       const {
@@ -763,12 +765,14 @@ describe('subscription graphql test suite', () => {
       });
       expect(subscription).to.equal(null);
 
+      console.log( `test remove a subscription exit, time: ${Date.now()}` );
     } catch (error) {
       if (error.response) {
         console.error('error encountered:  ', error.response.data);
       } else {
         console.error('error encountered:  ', error);
       }
+      console.log( `test remove a subscription error, time: ${Date.now()}` );
       throw error;
     }
   });

--- a/app/apollo/test/subscriptions.spec.js
+++ b/app/apollo/test/subscriptions.spec.js
@@ -706,6 +706,7 @@ describe('subscription graphql test suite', () => {
   it('set a subscription configurationVersion', async () => {
     console.log( `test setSubscription entry, time: ${Date.now()}` );
     try {
+      /*
       //step1, edit the subscription's configurationVerision
       const {
         data: {
@@ -718,7 +719,7 @@ describe('subscription graphql test suite', () => {
       });
       expect(setSubscription.uuid).to.be.an('string');
       expect(setSubscription.success).to.equal(true);
-      /*
+      */
       //step2, get the updated subscription
       const {
         data: {
@@ -728,8 +729,7 @@ describe('subscription graphql test suite', () => {
         orgId: org01._id,
         uuid: subscription_02_uuid,
       });
-      expect(subscription.versionUuid).to.equal(channelVersion_01_uuid);
-      */
+      //expect(subscription.versionUuid).to.equal(channelVersion_01_uuid);
       console.log( `test setSubscription exit, time: ${Date.now()}` );
     } catch (error) {
       if (error.response) {

--- a/app/apollo/test/subscriptions.spec.js
+++ b/app/apollo/test/subscriptions.spec.js
@@ -695,7 +695,7 @@ describe('subscription graphql test suite', () => {
       //PLC TEST, get the updated subscription
       const {
         data: {
-          data: { subscription },
+          data: { plcsubscription },
         },
       } = await subscriptionApi.subscription(adminToken, {
         orgId: org01._id,

--- a/app/apollo/test/subscriptions.spec.js
+++ b/app/apollo/test/subscriptions.spec.js
@@ -692,12 +692,6 @@ describe('subscription graphql test suite', () => {
       expect(result4.data.data.subscription.custom.forEnv).to.equal('new');
       expect(result4.data.data.subscription.custom.forType).to.equal('new');
 
-      //PLC TEST, get the updated subscription
-      const result5 = await subscriptionApi.subscription(token77, {
-        orgId: org77._id,
-        uuid: subscription_04_uuid,
-      });
-      console.log( `edit subscription completed the query that causes problem in 'set a sub' test, but with different values, time: ${Date.now()}` );
     } catch (error) {
       if (error.response) {
         console.error('error encountered:  ', error.response.data);
@@ -708,11 +702,9 @@ describe('subscription graphql test suite', () => {
     }
   });
 
-  //PLC dev note: if this test executes, the db will not disconnect :-( -- apparently either the setSubscription *or* the subscription (get) or both will trigger the problem.
   it('set a subscription configurationVersion', async () => {
     console.log( `test setSubscription entry, time: ${Date.now()}` );
     try {
-      /*
       //step1, edit the subscription's configurationVerision
       const {
         data: {
@@ -735,7 +727,6 @@ describe('subscription graphql test suite', () => {
         uuid: subscription_02_uuid,
       });
       expect(subscription.versionUuid).to.equal(channelVersion_01_uuid);
-      */
       console.log( `test setSubscription exit, time: ${Date.now()}` );
     } catch (error) {
       if (error.response) {

--- a/app/apollo/test/subscriptions.spec.js
+++ b/app/apollo/test/subscriptions.spec.js
@@ -635,7 +635,6 @@ describe('subscription graphql test suite', () => {
     }
   });
 
-  /*
   it('edit a subscription', async () => {
     try {
       //step1, edit the subscription
@@ -701,6 +700,7 @@ describe('subscription graphql test suite', () => {
     }
   });
 
+  /*
   it('set a subscription configurationVersion', async () => {
     try {
       //step1, edit the subscription's configurationVerision

--- a/app/apollo/test/subscriptions.spec.js
+++ b/app/apollo/test/subscriptions.spec.js
@@ -700,10 +700,12 @@ describe('subscription graphql test suite', () => {
     }
   });
 
+  //PLC dev note: if this test executes, the db will not disconnect :-(
   it('set a subscription configurationVersion', async () => {
     console.log( 'test setSubscription entry' );
     try {
       //step1, edit the subscription's configurationVerision
+      /*test Do not calling setSubscription temporarily
       const {
         data: {
           data: { setSubscription },
@@ -715,7 +717,7 @@ describe('subscription graphql test suite', () => {
       });
       expect(setSubscription.uuid).to.be.an('string');
       expect(setSubscription.success).to.equal(true);
-      /*
+      */
       //step2, get the updated subscription
       const {
         data: {
@@ -725,8 +727,7 @@ describe('subscription graphql test suite', () => {
         orgId: org01._id,
         uuid: subscription_02_uuid,
       });
-      expect(subscription.versionUuid).to.equal(channelVersion_01_uuid);
-      */
+      //test expect(subscription.versionUuid).to.equal(channelVersion_01_uuid);
       console.log( 'test setSubscription exit' );
     } catch (error) {
       if (error.response) {

--- a/app/apollo/test/subscriptions.spec.js
+++ b/app/apollo/test/subscriptions.spec.js
@@ -700,12 +700,10 @@ describe('subscription graphql test suite', () => {
     }
   });
 
-  //PLC dev note: if this test executes, the db will not disconnect :-(
   it('set a subscription configurationVersion', async () => {
     console.log( 'test setSubscription entry' );
     try {
       //step1, edit the subscription's configurationVerision
-      /*test Do not calling setSubscription temporarily
       const {
         data: {
           data: { setSubscription },
@@ -717,7 +715,7 @@ describe('subscription graphql test suite', () => {
       });
       expect(setSubscription.uuid).to.be.an('string');
       expect(setSubscription.success).to.equal(true);
-      */
+      /*PLC dev note: if this test executes, the db will not disconnect :-(
       //step2, get the updated subscription
       const {
         data: {
@@ -727,7 +725,8 @@ describe('subscription graphql test suite', () => {
         orgId: org01._id,
         uuid: subscription_02_uuid,
       });
-      //test expect(subscription.versionUuid).to.equal(channelVersion_01_uuid);
+      expect(subscription.versionUuid).to.equal(channelVersion_01_uuid);
+      */
       console.log( 'test setSubscription exit' );
     } catch (error) {
       if (error.response) {

--- a/app/apollo/test/subscriptions.spec.js
+++ b/app/apollo/test/subscriptions.spec.js
@@ -701,6 +701,7 @@ describe('subscription graphql test suite', () => {
   });
 
   it('set a subscription configurationVersion', async () => {
+    console.log( 'test setSubscription entry' );
     try {
       //step1, edit the subscription's configurationVerision
       const {
@@ -714,6 +715,7 @@ describe('subscription graphql test suite', () => {
       });
       expect(setSubscription.uuid).to.be.an('string');
       expect(setSubscription.success).to.equal(true);
+      /*
       //step2, get the updated subscription
       const {
         data: {
@@ -724,13 +726,15 @@ describe('subscription graphql test suite', () => {
         uuid: subscription_02_uuid,
       });
       expect(subscription.versionUuid).to.equal(channelVersion_01_uuid);
-
+      */
+      console.log( 'test setSubscription exit' );
     } catch (error) {
       if (error.response) {
         console.error('error encountered:  ', error.response.data);
       } else {
         console.error('error encountered:  ', error);
       }
+      console.log( 'test setSubscription error' );
       throw error;
     }
   });

--- a/app/apollo/test/subscriptions.spec.js
+++ b/app/apollo/test/subscriptions.spec.js
@@ -719,7 +719,6 @@ describe('subscription graphql test suite', () => {
       });
       expect(setSubscription.uuid).to.be.an('string');
       expect(setSubscription.success).to.equal(true);
-      */
       //step2, get the updated subscription
       const {
         data: {
@@ -729,7 +728,8 @@ describe('subscription graphql test suite', () => {
         orgId: org01._id,
         uuid: subscription_02_uuid,
       });
-      //expect(subscription.versionUuid).to.equal(channelVersion_01_uuid);
+      expect(subscription.versionUuid).to.equal(channelVersion_01_uuid);
+      */
       console.log( `test setSubscription exit, time: ${Date.now()}` );
     } catch (error) {
       if (error.response) {

--- a/app/apollo/test/subscriptions.spec.js
+++ b/app/apollo/test/subscriptions.spec.js
@@ -428,7 +428,9 @@ describe('subscription graphql test suite', () => {
   after(async () => {
     console.log( `subscription.spec.js after entry, time: ${Date.now()}` );
     await myApollo.stop(myApollo);
+    console.log( `subscription.spec.js apollo stopped, time: ${Date.now()}` );
     GraphqlPubSub.deleteInstance();
+    console.log( `subscription.spec.js pubsub deleted, time: ${Date.now()}` );
     await mongoServer.stop();
     console.log( `subscription.spec.js after exit, time: ${Date.now()}` );
   }); // after

--- a/app/apollo/test/subscriptions.spec.js
+++ b/app/apollo/test/subscriptions.spec.js
@@ -392,8 +392,6 @@ const sleep = async ( ms ) => {
 describe('subscription graphql test suite', () => {
 
   before(async () => {
-    console.log( `subscription.spec.js before entry, time: ${Date.now()}` );
-
     process.env.NODE_ENV = 'test';
     rbacSync.testMode(true); // Must be set to trigger/test RBAC Sync
 
@@ -422,17 +420,12 @@ describe('subscription graphql test suite', () => {
     //await getPresetOrgs();
     //await getPresetUsers();
     await getPresetClusters();
-    console.log( `subscription.spec.js before exit, time: ${Date.now()}` );
   }); // before
 
   after(async () => {
-    console.log( `subscription.spec.js after entry, time: ${Date.now()}` );
     await myApollo.stop(myApollo);
-    console.log( `subscription.spec.js apollo stopped, time: ${Date.now()}` );
     GraphqlPubSub.deleteInstance();
-    console.log( `subscription.spec.js pubsub deleted, time: ${Date.now()}` );
     await mongoServer.stop();
-    console.log( `subscription.spec.js after exit, time: ${Date.now()}` );
   }); // after
 
   it('get subscriptions', async () => {
@@ -703,7 +696,6 @@ describe('subscription graphql test suite', () => {
   });
 
   it('set a subscription configurationVersion', async () => {
-    console.log( `test setSubscription entry, time: ${Date.now()}` );
     try {
       //step1, edit the subscription's configurationVerision
       const {
@@ -727,20 +719,17 @@ describe('subscription graphql test suite', () => {
         uuid: subscription_02_uuid,
       });
       expect(subscription.versionUuid).to.equal(channelVersion_01_uuid);
-      console.log( `test setSubscription exit, time: ${Date.now()}` );
     } catch (error) {
       if (error.response) {
         console.error('error encountered:  ', error.response.data);
       } else {
         console.error('error encountered:  ', error);
       }
-      console.log( `test setSubscription error, time: ${Date.now()}` );
       throw error;
     }
   });
 
   it('remove a subscription', async () => {
-    console.log( `test remove a subscription entry, time: ${Date.now()}` );
     try {
       //step1, remove the subscription
       const {
@@ -763,15 +752,12 @@ describe('subscription graphql test suite', () => {
         uuid: subscription_01_uuid,
       });
       expect(subscription).to.equal(null);
-
-      console.log( `test remove a subscription exit, time: ${Date.now()}` );
     } catch (error) {
       if (error.response) {
         console.error('error encountered:  ', error.response.data);
       } else {
         console.error('error encountered:  ', error);
       }
-      console.log( `test remove a subscription error, time: ${Date.now()}` );
       throw error;
     }
   });

--- a/app/apollo/test/subscriptions.spec.js
+++ b/app/apollo/test/subscriptions.spec.js
@@ -693,15 +693,11 @@ describe('subscription graphql test suite', () => {
       expect(result4.data.data.subscription.custom.forType).to.equal('new');
 
       //PLC TEST, get the updated subscription
-      const {
-        data: {
-          data: { plcsubscription },
-        },
-      } = await subscriptionApi.subscription(adminToken, {
-        orgId: org01._id,
-        uuid: subscription_02_uuid,
+      const result5 = await subscriptionApi.subscription(token77, {
+        orgId: org77._id,
+        uuid: subscription_04_uuid,
       });
-      console.log( `edit subscription completed the query that causes problem in 'set a sub' test, time: ${Date.now()}` );
+      console.log( `edit subscription completed the query that causes problem in 'set a sub' test, but with different values, time: ${Date.now()}` );
     } catch (error) {
       if (error.response) {
         console.error('error encountered:  ', error.response.data);

--- a/app/apollo/test/subscriptions.spec.js
+++ b/app/apollo/test/subscriptions.spec.js
@@ -700,7 +700,6 @@ describe('subscription graphql test suite', () => {
     }
   });
 
-  /*
   it('set a subscription configurationVersion', async () => {
     try {
       //step1, edit the subscription's configurationVerision
@@ -735,7 +734,6 @@ describe('subscription graphql test suite', () => {
       throw error;
     }
   });
-  */
 
   it('remove a subscription', async () => {
     try {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "lodash": "^4.17.21",
     "moment": "^2.29.4",
     "mongodb": "^3.6.5",
-    "mongoose": "^6.4.6",
+    "mongoose": "^6.5.1",
     "mongoose-lean-defaults": "2.1.0",
     "mongoose-lean-virtuals": "^0.8.1",
     "mustache": "^4.1.0",


### PR DESCRIPTION
PR unit tests sometimes failing with errors like:
```
  1) subscription graphql test suite
       "after all" hook for "remove a subscription":
     Error: Timeout of 50000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/home/travis/build/alchemy-containers/satellite-config/node_modules/razeedash-api/app/apollo/test/subscriptions.spec.js)
      at listOnTimeout (node:internal/timers:559:17)
      at processTimers (node:internal/timers:502:7)
  2) user graphql
       "before all" hook in "user graphql":
     Uncaught Error: listen EADDRINUSE: address already in use :::18006
      at Server.setupListenHandle [as _listen2] (node:net:1372:16)
```
I.e. the first test fails to stop the server within 50 s and then the next test fails to start the server.  Exact cause is unclear, but is likely related to the update from mongoose v5.x to v6.x.  Adding additional logging... **and taking extra steps to close and disconnection from the database on shutdown**.