### PR TITLE
re-encryption, proper handling of orgkey query param

### DIFF
--- a/app/apollo/index.js
+++ b/app/apollo/index.js
@@ -86,7 +86,7 @@ const buildCommonApolloContext = async ({ models, req, res, connection }) => {
     const logger = req.log; // request context logger created by express-bunyan-logger
     const context = await initModule.buildApolloContext({ models, req, res, connection, logger });
     if (context.me && context.me.orgKey) {
-      const org = await models.Organization.findOne( { $or: [ { orgKeys: context.me.orgKey }, { orgKeys2.key: context.me.orgKey } ] } );
+      const org = await models.Organization.findOne( { $or: [ { orgKeys: context.me.orgKey }, { 'orgKeys2.key': context.me.orgKey } ] } );
       logger.fields.org_id = org._id;
     }
     if (context.me && context.me.org_id) {
@@ -181,7 +181,7 @@ const createSubscriptionServer = (httpServer, apolloServer, schema) => {
         let orgKey, orgId;
         if(connectionParams.headers && connectionParams.headers['razee-org-key']) {
           orgKey = connectionParams.headers['razee-org-key'];
-          const org = await models.Organization.findOne( { $or: [ { orgKeys: orgKey }, { orgKeys2.key: orgKey } ] } );
+          const org = await models.Organization.findOne( { $or: [ { orgKeys: orgKey }, { 'orgKeys2.key': orgKey } ] } );
           orgId = org._id;
         }
         const req_id = uuid();

--- a/app/apollo/index.js
+++ b/app/apollo/index.js
@@ -86,7 +86,7 @@ const buildCommonApolloContext = async ({ models, req, res, connection }) => {
     const logger = req.log; // request context logger created by express-bunyan-logger
     const context = await initModule.buildApolloContext({ models, req, res, connection, logger });
     if (context.me && context.me.orgKey) {
-      const org = await models.Organization.findOne({ orgKeys: context.me.orgKey });
+      const org = await models.Organization.findOne( { $or: [ { orgKeys: context.me.orgKey }, { orgKeys2.key: context.me.orgKey } ] } );
       logger.fields.org_id = org._id;
     }
     if (context.me && context.me.org_id) {
@@ -181,7 +181,7 @@ const createSubscriptionServer = (httpServer, apolloServer, schema) => {
         let orgKey, orgId;
         if(connectionParams.headers && connectionParams.headers['razee-org-key']) {
           orgKey = connectionParams.headers['razee-org-key'];
-          const org = await models.Organization.findOne({ orgKeys: orgKey });
+          const org = await models.Organization.findOne( { $or: [ { orgKeys: orgKey }, { orgKeys2.key: orgKey } ] } );
           orgId = org._id;
         }
         const req_id = uuid();

--- a/app/apollo/models/deployableVersion.schema.js
+++ b/app/apollo/models/deployableVersion.schema.js
@@ -42,6 +42,13 @@ const DeployableVersionSchema = new mongoose.Schema({
     type: String,
   },
   content: mongoose.Schema.Types.Mixed,
+  verifiedOrgKeyUuid: {
+    type: String,
+  },
+  desiredOrgKeyUuid: {
+    type: String,
+  },
+  /* iv is only used for legacy data, see ../utils/versionUtils.js for additional details */
   iv: {
     type: String,
   },

--- a/app/apollo/models/organization.local.schema.js
+++ b/app/apollo/models/organization.local.schema.js
@@ -16,7 +16,7 @@
 
 const mongoose = require('mongoose');
 const { v4: uuid } = require('uuid');
-const { bestOrgKeyValue } = require('../../utils/orgs');
+const { bestOrgKey } = require('../../utils/orgs');
 const OrganizationLocalSchema = new mongoose.Schema({
   _id: {
     type: String,
@@ -71,7 +71,7 @@ OrganizationLocalSchema.statics.getRegistrationUrl = async function(org_id, cont
     host = process.env.EXTERNAL_HOST;
   }
   return {
-    url: `${protocol}://${host}/api/install/razeedeploy-job?orgKey=${bestOrgKeyValue(org)}`,
+    url: `${protocol}://${host}/api/install/razeedeploy-job?orgKey=${bestOrgKey(org).key}`,
   };
 };
 

--- a/app/apollo/models/user.default.schema.js
+++ b/app/apollo/models/user.default.schema.js
@@ -154,7 +154,7 @@ UserDefaultSchema.statics.isAuthorized = async function(me, orgId, action, type,
 
 UserDefaultSchema.statics.isValidOrgKey = async function(models, me, logger) {
   logger.debug('default isValidOrgKey');
-  const org = await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { orgKeys2.key: me.orgKey } ] } ).lean();
+  const org = await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { 'orgKeys2.key': me.orgKey } ] } ).lean();
   if(!org) {
     logger.error('An org was not found for this razee-org-key');
     throw new ForbiddenError('org id was not found');
@@ -186,7 +186,7 @@ UserDefaultSchema.statics.getOrgById = async function(models, orgId) {
 };
 
 UserDefaultSchema.statics.getOrg = async function(models, me) {
-  return await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { orgKeys2.key: me.orgKey } ] } ).lean({ virtuals: true });
+  return await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { 'orgKeys2.key': me.orgKey } ] } ).lean({ virtuals: true });
 };
 
 UserDefaultSchema.statics.getBasicUsersByIds = async function(ids){

--- a/app/apollo/models/user.default.schema.js
+++ b/app/apollo/models/user.default.schema.js
@@ -154,7 +154,7 @@ UserDefaultSchema.statics.isAuthorized = async function(me, orgId, action, type,
 
 UserDefaultSchema.statics.isValidOrgKey = async function(models, me, logger) {
   logger.debug('default isValidOrgKey');
-  const org = await models.Organization.findOne({ orgKeys: me.orgKey }).lean();
+  const org = await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { orgKeys2.key: me.orgKey } ] } ).lean();
   if(!org) {
     logger.error('An org was not found for this razee-org-key');
     throw new ForbiddenError('org id was not found');
@@ -186,7 +186,7 @@ UserDefaultSchema.statics.getOrgById = async function(models, orgId) {
 };
 
 UserDefaultSchema.statics.getOrg = async function(models, me) {
-  return await models.Organization.findOne({ orgKeys: me.orgKey }).lean({ virtuals: true });
+  return await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { orgKeys2.key: me.orgKey } ] } ).lean({ virtuals: true });
 };
 
 UserDefaultSchema.statics.getBasicUsersByIds = async function(ids){

--- a/app/apollo/models/user.local.schema.js
+++ b/app/apollo/models/user.local.schema.js
@@ -268,7 +268,7 @@ UserLocalSchema.statics.getMeFromConnectionParams = async function(
 UserLocalSchema.statics.isValidOrgKey = async function(models, me, logger) {
   logger.debug('default isValidOrgKey');
 
-  const org = await models.Organization.findOne({ orgKeys: me.orgKey }).lean();
+  const org = await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { orgKeys2.key: me.orgKey } ] } ).lean();
   if(!org) {
     logger.error('An org was not found for this razee-org-key');
     throw new ForbiddenError('org id was not found');
@@ -341,7 +341,7 @@ UserLocalSchema.statics.isAuthorized = async function(me, orgId, action, type, a
 
 UserLocalSchema.statics.getOrg = async function(models, me) {
   let org;
-  org = await models.Organization.findOne({ orgKeys: me.orgKey }).lean({ virtuals: true });
+  org = await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { orgKeys2.key: me.orgKey } ] } ).lean({ virtuals: true });
   return org;
 };
 

--- a/app/apollo/models/user.local.schema.js
+++ b/app/apollo/models/user.local.schema.js
@@ -268,7 +268,7 @@ UserLocalSchema.statics.getMeFromConnectionParams = async function(
 UserLocalSchema.statics.isValidOrgKey = async function(models, me, logger) {
   logger.debug('default isValidOrgKey');
 
-  const org = await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { orgKeys2.key: me.orgKey } ] } ).lean();
+  const org = await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { 'orgKeys2.key': me.orgKey } ] } ).lean();
   if(!org) {
     logger.error('An org was not found for this razee-org-key');
     throw new ForbiddenError('org id was not found');
@@ -341,7 +341,7 @@ UserLocalSchema.statics.isAuthorized = async function(me, orgId, action, type, a
 
 UserLocalSchema.statics.getOrg = async function(models, me) {
   let org;
-  org = await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { orgKeys2.key: me.orgKey } ] } ).lean({ virtuals: true });
+  org = await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { 'orgKeys2.key': me.orgKey } ] } ).lean({ virtuals: true });
   return org;
 };
 

--- a/app/apollo/models/user.passport.local.schema.js
+++ b/app/apollo/models/user.passport.local.schema.js
@@ -273,7 +273,7 @@ UserPassportLocalSchema.statics.getMeFromConnectionParams = async function(
 UserPassportLocalSchema.statics.isValidOrgKey = async function(models, me, logger) {
   logger.debug('default isValidOrgKey');
 
-  const org = await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { orgKeys2.key: me.orgKey } ] } ).lean();
+  const org = await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { 'orgKeys2.key': me.orgKey } ] } ).lean();
   if(!org) {
     logger.error('An org was not found for this razee-org-key');
     throw new ForbiddenError('org id was not found');
@@ -341,7 +341,7 @@ UserPassportLocalSchema.statics.isAuthorized = async function(me, orgId, action,
 
 UserPassportLocalSchema.statics.getOrg = async function(models, me) {
   let org;
-  org = await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { orgKeys2.key: me.orgKey } ] } ).lean({ virtuals: true });
+  org = await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { 'orgKeys2.key': me.orgKey } ] } ).lean({ virtuals: true });
   return org;
 };
 

--- a/app/apollo/models/user.passport.local.schema.js
+++ b/app/apollo/models/user.passport.local.schema.js
@@ -273,7 +273,7 @@ UserPassportLocalSchema.statics.getMeFromConnectionParams = async function(
 UserPassportLocalSchema.statics.isValidOrgKey = async function(models, me, logger) {
   logger.debug('default isValidOrgKey');
 
-  const org = await models.Organization.findOne({ orgKeys: me.orgKey }).lean();
+  const org = await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { orgKeys2.key: me.orgKey } ] } ).lean();
   if(!org) {
     logger.error('An org was not found for this razee-org-key');
     throw new ForbiddenError('org id was not found');
@@ -341,7 +341,7 @@ UserPassportLocalSchema.statics.isAuthorized = async function(me, orgId, action,
 
 UserPassportLocalSchema.statics.getOrg = async function(models, me) {
   let org;
-  org = await models.Organization.findOne({ orgKeys: me.orgKey }).lean({ virtuals: true });
+  org = await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { orgKeys2.key: me.orgKey } ] } ).lean({ virtuals: true });
   return org;
 };
 

--- a/app/apollo/resolvers/channel.js
+++ b/app/apollo/resolvers/channel.js
@@ -23,6 +23,8 @@ const pLimit = require('p-limit');
 const { applyQueryFieldsToChannels, applyQueryFieldsToDeployableVersions } = require('../utils/applyQueryFields');
 const storageFactory = require('./../../storage/storageFactory');
 const yaml = require('js-yaml');
+const { bestOrgKey } = require('../../utils/orgs');
+const { getDecryptedContent, encryptAndStore } = require('../utils/versionUtils');
 
 const { ACTIONS, TYPES, CHANNEL_VERSION_YAML_MAX_SIZE_LIMIT_MB, CHANNEL_LIMITS, CHANNEL_VERSION_LIMITS } = require('../models/const');
 const { whoIs, validAuth, getAllowedChannels, filterChannelsToAllowed, NotFoundError, RazeeValidationError, BasicRazeeError, RazeeQueryError} = require ('./common');
@@ -134,7 +136,6 @@ const channelResolvers = {
         if (!org) {
           throw new NotFoundError(context.req.t('Could not find the organization with ID {{org_id}}.', {'org_id':org_id}), context);
         }
-        const orgKey = _.first(org.orgKeys);
 
         // search channel by channel uuid or channel name
         const channelFilter = channelName ? { name: channelName, org_id } : { uuid: channelUuid, org_id } ;
@@ -174,8 +175,14 @@ const channelResolvers = {
         }
         await applyQueryFieldsToDeployableVersions([ deployableVersionObj ], queryFields, { orgId: org_id }, context);
 
-        const handler = storageFactory(logger).deserialize(deployableVersionObj.content);
-        deployableVersionObj.content = await handler.getDataAndDecrypt(orgKey, deployableVersionObj.iv);
+        try {
+          const decryptedContentResult = await getDecryptedContent( context, org, deployableVersionObj );
+          deployableVersionObj.content = decryptedContentResult.content;
+        }
+        catch( e ) {
+          logger.error({req_id, user: whoIs(me), org_id, channelUuid, versionUuid, channelName, versionName }, `${queryName} encountered an error when decrypting version '${versionObj.uuid}' for request ${req_id}: ${e.message}`);
+          throw new RazeeQueryError(context.req.t('Query {{queryName}} error. MessageID: {{req_id}}.', {'queryName':queryName, 'req_id':req_id}), context);
+        }
 
         return deployableVersionObj;
       }catch(err){
@@ -296,7 +303,6 @@ const channelResolvers = {
       if (!org) {
         throw new NotFoundError(context.req.t('Could not find the organization with ID {{org_id}}.', {'org_id':org_id}), context);
       }
-      const orgKey = _.first(org.orgKeys);
 
       if(!name){
         throw new RazeeValidationError(context.req.t('A "name" must be specified'), context);
@@ -353,12 +359,7 @@ const channelResolvers = {
       }
 
       const newVerUuid = UUID();
-      const path = `${org_id.toLowerCase()}-${channel.uuid}-${newVerUuid}`;
-      const bucketName = conf.storage.getChannelBucket(channel.data_location);
-      const handler = storageFactory(logger).newResourceHandler(path, bucketName, channel.data_location);
-      const ivText = await handler.setDataAndEncrypt(content, orgKey);
-      const data = handler.serialize();
-
+      const orgKey = bestOrgKey( org );
       const kubeOwnerId = await models.User.getKubeOwnerId(context);
       const deployableVersionObj = {
         _id: UUID(),
@@ -368,12 +369,14 @@ const channelResolvers = {
         channelName: channel.name,
         name,
         description,
-        content: data,
-        iv: ivText,
         type,
         ownerId: me._id,
         kubeOwnerId,
+        verifiedOrgKeyUuid: orgKey.orgKeyUuid,
+        desiredOrgKeyUuid: orgKey.orgKeyUuid,
       };
+      const { data } = await encryptAndStore( context, org, channel, deployableVersionObj, orgKey, content);
+      deployableVersionObj.content = data;
 
       // Note: if failure occurs here, the data has already been stored by storageFactory.
       // A cleanup mechanism is needed.

--- a/app/apollo/resolvers/cluster.js
+++ b/app/apollo/resolvers/cluster.js
@@ -22,7 +22,7 @@ const GraphqlFields = require('graphql-fields');
 const _ = require('lodash');
 const { convertStrToTextPropsObj } = require('../utils');
 const { applyQueryFieldsToClusters } = require('../utils/applyQueryFields');
-const { bestOrgKeyValue } = require('../../utils/orgs');
+const { bestOrgKey } = require('../../utils/orgs');
 
 
 const { validateString, validateJson } = require('../utils/directives');
@@ -477,7 +477,7 @@ const clusterResolvers = {
             url += `&args=${arg}`;
           });
         }
-        return { url, orgId: org_id, clusterId: cluster_id, orgKey: bestOrgKeyValue( org ), regState: reg_state, registration };
+        return { url, orgId: org_id, clusterId: cluster_id, orgKey: bestOrgKey( org ).key, regState: reg_state, registration };
       } catch (error) {
         if(error instanceof BasicRazeeError ){
           throw error;

--- a/app/apollo/resolvers/organization.js
+++ b/app/apollo/resolvers/organization.js
@@ -459,14 +459,14 @@ const organizationResolvers = {
           // Start ASYNCHRONOUSLY updating Version encryption
           updateAllVersionEncryption( context, org, versions, orgKey ).then( (result) => {
             if( result.incomplete > 0 ) {
-              logger.info({ req_id, user: whoIs(me), orgId, name, primary, res, newOrgKey: newOrgKey.orgKeyUuid, result }, `${queryName} version re-encryption to use '${orgKey.orgKeyUuid}' was interrupted by additional changes, result: ${JSON.stringify(result)}`);
+              logger.info({ req_id, user: whoIs(me), orgId, name, primary, res }, `${queryName} version re-encryption to use '${orgKey.orgKeyUuid}' was interrupted by additional changes, result: ${JSON.stringify(result)}`);
             }
             else if( result.failed > 0 ) {
               // This is not fatal -- Versions still keep track of both the verifiedOrgKeyUuid and desiredOrgKeyUuid, and can use one of the two to decrypt existing data.
-              logger.warn({ req_id, user: whoIs(me), orgId, name, primary, res, newOrgKey: newOrgKey.orgKeyUuid, result }, `${queryName} version re-encryption to use '${orgKey.orgKeyUuid}' encountered errors, result: ${JSON.stringify(result)}`);
+              logger.warn({ req_id, user: whoIs(me), orgId, name, primary, res }, `${queryName} version re-encryption to use '${orgKey.orgKeyUuid}' encountered errors, result: ${JSON.stringify(result)}`);
             }
             else {
-              logger.info({ req_id, user: whoIs(me), orgId, name, primary, res, newOrgKey: newOrgKey.orgKeyUuid, result }, `${queryName} version re-encryption to use '${orgKey.orgKeyUuid}' was sucessful, result: ${JSON.stringify(result)}`);
+              logger.info({ req_id, user: whoIs(me), orgId, name, primary, res }, `${queryName} version re-encryption to use '${orgKey.orgKeyUuid}' was sucessful, result: ${JSON.stringify(result)}`);
             }
           }).catch( (e) => {
             // The only error that should be thrown is 'already in progress', which is ignored

--- a/app/apollo/resolvers/organization.js
+++ b/app/apollo/resolvers/organization.js
@@ -20,6 +20,9 @@ const { v4: UUID } = require('uuid');
 
 const { validateString } = require('../utils/directives');
 
+const { getLegacyOrgKeyObject, bestOrgKey } = require( '../../utils/orgs' );
+const { updateAllVersionEncryption } = require( '../utils/versionUtils' );
+
 // Limit orgKeys to a small number.  In normal usage there should never be more than two or three (previous orgkey, new primary orgkey).
 const ORGKEY_LIMIT = 5;
 
@@ -201,6 +204,30 @@ const organizationResolvers = {
             // If an error occurs while removing Primary from other OrgKeys, it can be logged and ignored -- the actual creation of the new OrgKey did succeed before this point is reached.
             logger.error({ req_id, user: whoIs(me), orgId, name, primary, res, error: error.message }, `${queryName} error removing primary from other OrgKeys, continuing`);
           }
+
+          /*
+          The OrgKeys (originally just hard coded as the first `orgKeys` element before OrgKey management was enabled) are used to encrypt/decrypt Version content stored in S3 or embedded.
+          When a new Primary OrgKey is identified, existing encrypted data must be re-encrypted so the old OrgKey can be eventually deleted.
+          Only Versions need to be updated as only Versions use encryption when storing/retrieving data.  Resources just use setData/getData methods.
+          Re-encryption is ASYNCHRONOUS and could fail for various reasons (pod evicted, database failure, etc), so re-encryption is triggered again when attempting to delete any OrgKey that is still used for encryption.
+          */
+          const versions = await models.DeployableVersion.find({ org_id: orgId });
+          // Start ASYNCHRONOUSLY updating Version encryption
+          updateAllVersionEncryption( context, org, versions, newOrgKey ).then( (result) => {
+            if( result.incomplete > 0 ) {
+              logger.info({ req_id, user: whoIs(me), orgId, name, primary, res, newOrgKey: newOrgKey.orgKeyUuid, result }, `${queryName} version re-encryption to use '${newOrgKey.orgKeyUuid}' was interrupted by additional changes, result: ${JSON.stringify(result)}`);
+            }
+            else if( result.failed > 0 ) {
+              // This is not fatal -- Versions still keep track of both the verifiedOrgKeyUuid and desiredOrgKeyUuid, and can use one of the two to decrypt existing data.
+              logger.warn({ req_id, user: whoIs(me), orgId, name, primary, res, newOrgKey: newOrgKey.orgKeyUuid, result }, `${queryName} version re-encryption to use '${newOrgKey.orgKeyUuid}' encountered errors, result: ${JSON.stringify(result)}`);
+            }
+            else {
+              logger.info({ req_id, user: whoIs(me), orgId, name, primary, res, newOrgKey: newOrgKey.orgKeyUuid, result }, `${queryName} version re-encryption to use '${newOrgKey.orgKeyUuid}' was sucessful, result: ${JSON.stringify(result)}`);
+            }
+          }).catch( (e) => {
+            // The only error that should be thrown is 'already in progress', which is unexpected here as a NEW OrgKey is being created, but can be ignored.
+            logger.warning({ req_id, user: whoIs(me), orgId, name, primary, res, error: e.message }, `${queryName} version re-encryption to use '${newOrgKey.orgKeyUuid}' is already in progress`);
+          });
         }
 
         // Return the new orgKey uuid and key value
@@ -250,14 +277,7 @@ const organizationResolvers = {
         if( org.orgKeys ) {
           allOrgKeys.push(
             ...org.orgKeys.map( legacyOrgKey => {
-              return {
-                uuid: legacyOrgKey,
-                name: legacyOrgKey.slice( legacyOrgKey.length - 12 ),  // last segment of legacy key, which is essentially a UUID prefixed by `orgApiKey-`
-                primary: false,
-                created: null,
-                updated: null,
-                key: legacyOrgKey
-              };
+              return getLegacyOrgKeyObject( legacyOrgKey );
             } )
           );
           logger.info({ req_id, user: whoIs(me), orgId, uuid, forceDeletion }, `${queryName} legacy OrgKeys added: ${org.orgKeys.length}`);
@@ -265,21 +285,12 @@ const organizationResolvers = {
 
         // Add OrgKeys2
         allOrgKeys.push(
-          ...org.orgKeys2.map( orgKey => {
-            return {
-              uuid: orgKey.orgKeyUuid,
-              name: orgKey.name,
-              primary: orgKey.primary,
-              created: orgKey.created,
-              updated: orgKey.updated,
-              key: orgKey.key
-            };
-          } )
+          ...org.orgKeys2
         );
         logger.info({ req_id, user: whoIs(me), orgId, uuid, forceDeletion }, `${queryName} OrgKeys2 added: ${org.orgKeys2.length}`);
 
         const foundOrgKey = allOrgKeys.find( e => {
-          return( e.uuid === uuid );
+          return( e.orgKeyUuid === uuid );
         } );
 
         if( !foundOrgKey ){
@@ -287,18 +298,50 @@ const organizationResolvers = {
           throw new NotFoundError( context.req.t( 'Could not find the organization key.' ), context );
         }
 
-        // Ensure not removing the first orgKey - temporary restriction as it is used to encrypt deployable versions content before storage
-        if( org.orgKeys[0] == uuid ) {
-          // Forbidden, cannot force!
-          logger.warn({ req_id, user: whoIs(me), orgId, uuid, forceDeletion }, `${queryName} OrgKey cannot be removed because it is in use (encryption)` );
-          throw new RazeeForbiddenError( context.req.t( 'Organization key {{id}} cannot be removed or altered because it is in use.', {id: uuid} ), context );
+        /*
+        The OrgKeys (originally just hard coded as the first `orgKeys` element before OrgKey management was enabled) are used to encrypt/decrypt Version content stored in S3 or embedded.
+        When a new Primary OrgKey is identified, existing encrypted data must be re-encrypted so the old OrgKey can be eventually deleted.
+        Only Versions need to be updated as only Versions use encryption when storing/retrieving data.  Resources just use setData/getData methods.
+        Re-encryption is ASYNCHRONOUS and could fail for various reasons (pod evicted, database failure, etc), so re-encryption is triggered again when attempting to delete any OrgKey that is still used for encryption.
+        */
+        // Ensure not removing a potentially in-use OrgKey (for version content encryption) (cannot force)
+        const versionsUsingOrgKey = await models.DeployableVersion.find({ org_id: orgId, $or: [ { verifiedOrgKeyUuid: { $exists: false } }, { desiredOrgKeyUuid: { $exists: false } }, {verifiedOrgKeyUuid: foundOrgKey.orgKeyUuid}, {desiredOrgKeyUuid: foundOrgKey.orgKeyUuid} ] });
+        if( versionsUsingOrgKey.length > 0 ) {
+          // Forbidden
+          logger.warn({ req_id, user: whoIs(me), orgId, uuid, forceDeletion }, `${queryName} OrgKey cannot be removed because it is in use (version encryption).` );
+
+          // If NOT deleting the best OrgKey...
+          const newOrgKey = bestOrgKey(org);
+          if( newOrgKey.orgKeyUuid != uuid ) {
+            // Start ASYNCHRONOUSLY updating Version encryption
+            updateAllVersionEncryption( context, org, versionsUsingOrgKey, newOrgKey ).then( (result) => {
+              if( result.incomplete > 0 ) {
+                logger.info({ req_id, user: whoIs(me), orgId, newOrgKey: newOrgKey.orgKeyUuid, result }, `${queryName} version re-encryption to use '${newOrgKey.orgKeyUuid}' was interrupted by additional changes, result: ${JSON.stringify(result)}`);
+              }
+              else if( result.failed > 0 ) {
+                // This is not fatal -- Versions still keep track of both the verifiedOrgKeyUuid and desiredOrgKeyUuid, and can use one of the two to decrypt existing data.
+                logger.warn({ req_id, user: whoIs(me), orgId, newOrgKey: newOrgKey.orgKeyUuid, result }, `${queryName} version re-encryption to use '${newOrgKey.orgKeyUuid}' encountered errors, result: ${JSON.stringify(result)}`);
+              }
+              else {
+                logger.info({ req_id, user: whoIs(me), orgId, newOrgKey: newOrgKey.orgKeyUuid, result }, `${queryName} version re-encryption to use '${newOrgKey.orgKeyUuid}' was successful, result: ${JSON.stringify(result)}`);
+              }
+            }).catch( (e) => {
+              // The only error that should be thrown is 'already in progress', which is ignored
+              logger.info({ req_id, user: whoIs(me), orgId, error: e.message }, `${queryName} version re-encryption to use '${newOrgKey.orgKeyUuid}' is already in progress`);
+            });
+
+            throw new RazeeForbiddenError( context.req.t( 'Organization key {{id}} cannot be removed or altered because it is in use for data encryption.  Data re-encryption is in progress, please try again in a few minutes.', {id: uuid} ), context );
+          }
+          else {
+            throw new RazeeForbiddenError( context.req.t( 'Organization key {{id}} cannot be removed or altered because it is in use for data encryption.  Create a new key and then wait a few minutes before retrying.', {id: uuid} ), context );
+          }
         }
 
-        // Ensure not removing the last OrgKey, unless forced
+        // Ensure not removing the last OrgKey (cannot force)
         if( allOrgKeys.length == 1 ) {
           // Forbidden
           logger.warn({ req_id, user: whoIs(me), orgId, uuid, forceDeletion }, `${queryName} OrgKey cannot be removed because it is in use (last one)` );
-          if( !forceDeletion ) throw new RazeeForbiddenError( context.req.t( 'Organization key {{id}} cannot be removed or altered because it is in use.', {id: uuid} ), context );
+          throw new RazeeForbiddenError( context.req.t( 'Organization key {{id}} cannot be removed or altered because it is the last one.', {id: uuid} ), context );
         }
 
         // Ensure not removing an orgKey that was the last one used by at least one managed cluster, unless forced
@@ -307,9 +350,9 @@ const organizationResolvers = {
           lastOrgKeyUuid: uuid,
         } ).lean({ virtuals: true });
         if( clusterUsingOrgKey ) {
-          // Forbidden
+          // Forbidden, but can force (stopped/deleted cluster might never report in again, or update its orgkey)
           logger.warn({ req_id, user: whoIs(me), orgId, uuid, forceDeletion }, `${queryName} OrgKey cannot be removed because it is in use (cluster)` );
-          if( !forceDeletion ) throw new RazeeForbiddenError( context.req.t( 'Organization key {{id}} cannot be removed or altered because it is in use.', {id: uuid} ), context );
+          if( !forceDeletion ) throw new RazeeForbiddenError( context.req.t( 'Organization key {{id}} cannot be removed or altered because it is in use by one or more clusters.', {id: uuid} ), context );
         }
 
         // Remove the OrgKey from both orgKeys and orgKeys2
@@ -318,10 +361,11 @@ const organizationResolvers = {
           orgKeys2: { orgKeyUuid: uuid }
         };
         await models.Organization.updateOne( { _id: orgId }, { $pull: pull } );
-        logger.info({ req_id, user: whoIs(me), orgId, uuid, forceDeletion }, `${queryName} OrgKey removed`);
+        logger.info({ req_id, user: whoIs(me), orgId, uuid, forceDeletion }, `${queryName} OrgKey with value '${foundOrgKey.key}' removed`);
 
         return { success: true };
-      } catch (error) {
+      }
+      catch (error) {
         // Note: if using an external auth plugin, it's organization schema must define the OrgKeys2 attribute else query will throw an error.
 
         if(error instanceof BasicRazeeError ){
@@ -378,7 +422,7 @@ const organizationResolvers = {
           if( orgKey.primary && primaryOrgKeys.length < 2 ) {
             // Forbidden
             logger.warn({ req_id, user: whoIs(me), orgId, uuid }, `${queryName} OrgKey cannot be altered because it is in use (primary)` );
-            throw new RazeeForbiddenError( context.req.t( 'Organization key {{id}} cannot be removed or altered because it is in use.', {id: uuid} ), context );
+            throw new RazeeForbiddenError( context.req.t( 'Organization key {{id}} cannot be removed or altered because it is the only Primary key.', {id: uuid} ), context );
           }
         }
 

--- a/app/apollo/test/externalAuth/organization.local.schema.js
+++ b/app/apollo/test/externalAuth/organization.local.schema.js
@@ -69,8 +69,12 @@ OrganizationLocalSchema.statics.getRegistrationUrl = async function(org_id, cont
   if (process.env.EXTERNAL_HOST) {
     host = process.env.EXTERNAL_HOST;
   }
+  let bestOrgKeyValue = org.orgKeys[0];
+  if( org.orgKeys2 && org.orgKeys2.length > 0 ) {
+    bestOrgKeyValue = ( org.orgKeys2.find( ok => { return ok.primary } ) || org.orgKeys2[0] ).key;
+  }
   return {
-    url: `${protocol}://${host}/api/install/razeedeploy-job?orgKey=${org.orgKeys[0]}`,
+    url: `${protocol}://${host}/api/install/razeedeploy-job?orgKey=${bestOrgKeyValue}`,
   };
 };
 

--- a/app/apollo/test/externalAuth/organization.local.schema.js
+++ b/app/apollo/test/externalAuth/organization.local.schema.js
@@ -15,9 +15,7 @@
  */
 
 const mongoose = require('mongoose');
-const { bestOrgKeyValue } = require('razeedash-api/app/utils/orgs');
 const { v4: uuid } = require('uuid');
-
 const OrganizationLocalSchema = new mongoose.Schema({
   _id: {
     type: String,
@@ -72,7 +70,7 @@ OrganizationLocalSchema.statics.getRegistrationUrl = async function(org_id, cont
     host = process.env.EXTERNAL_HOST;
   }
   return {
-    url: `${protocol}://${host}/api/install/razeedeploy-job?orgKey=${bestOrgKeyValue(org)}`,
+    url: `${protocol}://${host}/api/install/razeedeploy-job?orgKey=${org.orgKeys[0]}`,
   };
 };
 

--- a/app/apollo/test/externalAuth/organization.local.schema.js
+++ b/app/apollo/test/externalAuth/organization.local.schema.js
@@ -71,7 +71,7 @@ OrganizationLocalSchema.statics.getRegistrationUrl = async function(org_id, cont
   }
   let bestOrgKeyValue = org.orgKeys[0];
   if( org.orgKeys2 && org.orgKeys2.length > 0 ) {
-    bestOrgKeyValue = ( org.orgKeys2.find( ok => { return ok.primary } ) || org.orgKeys2[0] ).key;
+    bestOrgKeyValue = ( org.orgKeys2.find( key => { return key.primary; } ) || org.orgKeys2[0] ).key;
   }
   return {
     url: `${protocol}://${host}/api/install/razeedeploy-job?orgKey=${bestOrgKeyValue}`,

--- a/app/apollo/test/externalAuth/organization.local.schema.js
+++ b/app/apollo/test/externalAuth/organization.local.schema.js
@@ -15,7 +15,9 @@
  */
 
 const mongoose = require('mongoose');
+const { bestOrgKeyValue } = require('razeedash-api/app/utils/orgs');
 const { v4: uuid } = require('uuid');
+
 const OrganizationLocalSchema = new mongoose.Schema({
   _id: {
     type: String,
@@ -70,7 +72,7 @@ OrganizationLocalSchema.statics.getRegistrationUrl = async function(org_id, cont
     host = process.env.EXTERNAL_HOST;
   }
   return {
-    url: `${protocol}://${host}/api/install/razeedeploy-job?orgKey=${org.orgKeys[0]}`,
+    url: `${protocol}://${host}/api/install/razeedeploy-job?orgKey=${bestOrgKeyValue(org)}`,
   };
 };
 

--- a/app/apollo/test/externalAuth/user.local.schema.js
+++ b/app/apollo/test/externalAuth/user.local.schema.js
@@ -268,7 +268,7 @@ UserLocalSchema.statics.getMeFromConnectionParams = async function(
 UserLocalSchema.statics.isValidOrgKey = async function(models, me, logger) {
   logger.debug('default isValidOrgKey');
 
-  const org = await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { orgKeys2.key: me.orgKey } ] } ).lean();
+  const org = await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { 'orgKeys2.key': me.orgKey } ] } ).lean();
   if(!org) {
     logger.error('An org was not found for this razee-org-key');
     throw new ForbiddenError('org id was not found');
@@ -342,7 +342,7 @@ UserLocalSchema.statics.isAuthorized = async function(me, orgId, action, type, a
 
 UserLocalSchema.statics.getOrg = async function(models, me) {
   let org;
-  org = await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { orgKeys2.key: me.orgKey } ] } ).lean({ virtuals: true });
+  org = await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { 'orgKeys2.key': me.orgKey } ] } ).lean({ virtuals: true });
   return org;
 };
 

--- a/app/apollo/test/externalAuth/user.local.schema.js
+++ b/app/apollo/test/externalAuth/user.local.schema.js
@@ -268,7 +268,7 @@ UserLocalSchema.statics.getMeFromConnectionParams = async function(
 UserLocalSchema.statics.isValidOrgKey = async function(models, me, logger) {
   logger.debug('default isValidOrgKey');
 
-  const org = await models.Organization.findOne({ orgKeys: me.orgKey }).lean();
+  const org = await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { orgKeys2.key: me.orgKey } ] } ).lean();
   if(!org) {
     logger.error('An org was not found for this razee-org-key');
     throw new ForbiddenError('org id was not found');
@@ -342,7 +342,7 @@ UserLocalSchema.statics.isAuthorized = async function(me, orgId, action, type, a
 
 UserLocalSchema.statics.getOrg = async function(models, me) {
   let org;
-  org = await models.Organization.findOne({ orgKeys: me.orgKey }).lean({ virtuals: true });
+  org = await models.Organization.findOne( { $or: [ { orgKeys: me.orgKey }, { orgKeys2.key: me.orgKey } ] } ).lean({ virtuals: true });
   return org;
 };
 

--- a/app/apollo/test/organization.spec.js
+++ b/app/apollo/test/organization.spec.js
@@ -131,7 +131,6 @@ describe('organization graphql test suite', () => {
     let orgKeyVal1 = null;
     let channel1Uuid = null;
     let initialOrgKeyVersionUuid = null;
-    let remainingOrgKeyVersionUuid = null;
 
     it('a user should be able to get organizations associated with him.', async () => {
       try {
@@ -139,7 +138,7 @@ describe('organization graphql test suite', () => {
 
         const response = await api.organizations(token);
         console.log( `organizations (user01) response: ${JSON.stringify( response.data, null, 2 )}` );
-        if (response.data.errors) expect.fail(errors[0].message);
+        if (response.data.errors && response.data.errors.length > 0) expect.fail(response.data.errors[0].message);
         const organizations = response.data.data.organizations;
 
         expect(organizations).to.be.a('array');
@@ -157,7 +156,7 @@ describe('organization graphql test suite', () => {
 
         const response = await api.organizations(token);
         console.log( `organizations (admin) response: ${JSON.stringify( response.data, null, 2 )}` );
-        if (response.data.errors) expect.fail(errors[0].message);
+        if (response.data.errors && response.data.errors.length > 0) expect.fail(response.data.errors[0].message);
         const organizations = response.data.data.organizations;
 
         expect(organizations).to.be.a('array');
@@ -179,7 +178,7 @@ describe('organization graphql test suite', () => {
           orgId: adminOrg.id
         });
         console.log( `orgKeys response: ${JSON.stringify( response.data, null, 2 )}` );
-        if (response.data.errors) expect.fail(errors[0].message);
+        if (response.data.errors && response.data.errors.length > 0) expect.fail(response.data.errors[0].message);
         const orgKeys = response.data.data.orgKeys;
 
         expect(orgKeys).to.be.a('array');
@@ -205,7 +204,7 @@ describe('organization graphql test suite', () => {
           data_location: 'dal'
         });
         console.log( `addChannel 'a_random_name' response: ${JSON.stringify( response.data, null, 2 )}` );
-        if (response.data.errors) expect.fail(errors[0].message);
+        if (response.data.errors && response.data.errors.length > 0) expect.fail(response.data.errors[0].message);
         const addChannel = response.data.data.addChannel;
 
         channel1Uuid = addChannel.uuid;
@@ -219,7 +218,7 @@ describe('organization graphql test suite', () => {
           description: 'Version encrypted with origOrgKey'
         });
         console.log( `addChannelVersion 'ver1-origOrgKey' response: ${JSON.stringify( response.data, null, 2 )}` );
-        if (response.data.errors) expect.fail(errors[0].message);
+        if (response.data.errors && response.data.errors.length > 0) expect.fail(response.data.errors[0].message);
         const addChannelVersion = response.data.data.addChannelVersion;
 
         expect(addChannelVersion.success).to.equal(true);
@@ -248,7 +247,7 @@ describe('organization graphql test suite', () => {
           primary: true
         });
         console.log( `addOrgKey '${orgKeyName1}' response: ${JSON.stringify( response.data, null, 2 )}` );
-        if (response.data.errors) expect.fail(errors[0].message);
+        if (response.data.errors && response.data.errors.length > 0) expect.fail(response.data.errors[0].message);
         const addOrgKey = response.data.data.addOrgKey;
         expect(addOrgKey.uuid).to.be.an('string');
 
@@ -282,7 +281,7 @@ describe('organization graphql test suite', () => {
           primary: true
         });
         console.log( `addOrgKey '${orgKeyName2}' response: ${JSON.stringify( response.data, null, 2 )}` );
-        if (response.data.errors) expect.fail(errors[0].message);
+        if (response.data.errors && response.data.errors.length > 0) expect.fail(response.data.errors[0].message);
         const addOrgKey = response.data.data.addOrgKey;
         expect(addOrgKey.uuid).to.be.an('string');
 
@@ -313,7 +312,7 @@ describe('organization graphql test suite', () => {
           orgId: adminOrg.id
         });
         console.log( `orgKeys response: ${JSON.stringify( response.data, null, 2 )}` );
-        if (response.data.errors) expect.fail(errors[0].message);
+        if (response.data.errors && response.data.errors.length > 0) expect.fail(response.data.errors[0].message);
         const orgKeys = response.data.data.orgKeys;
 
         expect(orgKeys).to.be.a('array');
@@ -337,7 +336,7 @@ describe('organization graphql test suite', () => {
           name: null
         });
         console.log( `orgKey '${orgKeyUuid1}' response: ${JSON.stringify( response.data, null, 2 )}` );
-        if (response.data.errors) expect.fail(errors[0].message);
+        if (response.data.errors && response.data.errors.length > 0) expect.fail(response.data.errors[0].message);
         const orgKey = response.data.data.orgKey;
 
         expect(orgKey.uuid).to.equal(orgKeyUuid1);
@@ -365,7 +364,7 @@ describe('organization graphql test suite', () => {
           name: orgKeyName2
         });
         console.log( `orgKey '${orgKeyName2}' response: ${JSON.stringify( response.data, null, 2 )}` );
-        if (response.data.errors) expect.fail(errors[0].message);
+        if (response.data.errors && response.data.errors.length > 0) expect.fail(response.data.errors[0].message);
         const orgKey = response.data.data.orgKey;
 
         expect(orgKey.uuid).to.equal(orgKeyUuid2);
@@ -392,7 +391,7 @@ describe('organization graphql test suite', () => {
           primary: true
         });
         console.log( `editOrgKey '${orgKeyUuid1}' response: ${JSON.stringify( response.data, null, 2 )}` );
-        if (response.data.errors) expect.fail(errors[0].message);
+        if (response.data.errors && response.data.errors.length > 0) expect.fail(response.data.errors[0].message);
         const editOrgKey = response.data.data.editOrgKey;
 
         expect(editOrgKey.modified).to.equal(1);
@@ -420,7 +419,7 @@ describe('organization graphql test suite', () => {
           name: orgKeyName1+'_newname'
         });
         console.log( `orgKey '${orgKeyName1+'_newname'}' response: ${JSON.stringify( response.data, null, 2 )}` );
-        if (response.data.errors) expect.fail(errors[0].message);
+        if (response.data.errors && response.data.errors.length > 0) expect.fail(response.data.errors[0].message);
         const orgKey = response.data.data.orgKey;
 
         expect(orgKey.uuid).to.equal(orgKeyUuid1);
@@ -446,7 +445,7 @@ describe('organization graphql test suite', () => {
           uuid: orgKeyUuid0
         });
         console.log( `removeOrgKey '${orgKeyUuid0}' response: ${JSON.stringify( response.data, null, 2 )}` );
-        if (response.data.errors) expect.fail(errors[0].message);
+        if (response.data.errors && response.data.errors.length > 0) expect.fail(response.data.errors[0].message);
         const removeOrgKey = response.data.data.removeOrgKey;
 
         expect(removeOrgKey.success).to.equal(true);
@@ -477,7 +476,7 @@ describe('organization graphql test suite', () => {
           uuid: orgKeyUuid2
         });
         console.log( `removeOrgKey '${orgKeyUuid2}' response: ${JSON.stringify( response.data, null, 2 )}` );
-        if (response.data.errors) expect.fail(errors[0].message);
+        if (response.data.errors && response.data.errors.length > 0) expect.fail(response.data.errors[0].message);
         const removeOrgKey = response.data.data.removeOrgKey;
 
         expect(removeOrgKey.success).to.equal(true);
@@ -541,7 +540,7 @@ describe('organization graphql test suite', () => {
           registration: { name: 'newOrgKeyCluster' },
         });
         console.log( `registerCluster 'newOrgKeyCluster' response: ${JSON.stringify( response.data, null, 2 )}` );
-        if (response.data.errors) expect.fail(errors[0].message);
+        if (response.data.errors && response.data.errors.length > 0) expect.fail(response.data.errors[0].message);
         const registerCluster = response.data.data.registerCluster;
 
         expect(registerCluster.url).to.be.an('string');
@@ -568,11 +567,10 @@ describe('organization graphql test suite', () => {
           description: 'Version encrypted with remainingOrgKey'
         });
         console.log( `addChannelVersion 'ver2-remainingOrgKey' response: ${JSON.stringify( response.data, null, 2 )}` );
-        if (response.data.errors) expect.fail(errors[0].message);
+        if (response.data.errors && response.data.errors.length > 0) expect.fail(response.data.errors[0].message);
         const addChannelVersion = response.data.data.addChannelVersion;
 
         expect(addChannelVersion.success).to.equal(true);
-        remainingOrgKeyVersionUuid = addChannelVersion.versionUuid;
       } catch (error) {
         if (error.response) {
           console.error('error encountered:  ', error.response.data);
@@ -583,7 +581,7 @@ describe('organization graphql test suite', () => {
       }
     });
 
-    it('debug all versions', async () => {
+    it('Version contents originally encrypted with different OrgKeys should be retrievable', async () => {
       token = await signInUser(models, api, rootData);
       try {
         // Get all Versions from the DB
@@ -598,7 +596,7 @@ describe('organization graphql test suite', () => {
             versionUuid: v.uuid,
           });
           console.log( `version '${v.uuid} response': ${JSON.stringify( response.data, null, 2 )}` );
-          if (response.data.errors) expect.fail(errors[0].message);
+          if (response.data.errors && response.data.errors.length > 0) expect.fail(response.data.errors[0].message);
           const channelVersion = response.data.data.channelVersion;
 
           expect(channelVersion.content).to.contain('This content encrypted with');

--- a/app/apollo/test/organization.spec.js
+++ b/app/apollo/test/organization.spec.js
@@ -19,6 +19,8 @@ const fs = require('fs');
 const { MongoMemoryServer } = require('mongodb-memory-server');
 
 const apiFunc = require('./api');
+const clusterFunc = require('./clusterApi');
+const channelFunc = require('./channelApi');
 const { models } = require('../models');
 const apollo = require('../index');
 const { AUTH_MODEL } = require('../models/const');
@@ -34,6 +36,8 @@ let myApollo;
 const graphql_port = 18003;
 const graphql_url = `http://localhost:${graphql_port}/graphql`;
 const api = apiFunc(graphql_url);
+const channelApi = channelFunc(graphql_url);
+const clusterApi = clusterFunc(graphql_url);
 
 const orgKeyFunc = require('./orgKeyApi');
 const orgKeyApi = orgKeyFunc(graphql_url);
@@ -102,6 +106,8 @@ describe('organization graphql test suite', () => {
     await createOrganizations();
     await createUsers();
 
+    //await createChannel();
+
     await getPresetOrgs();
     await getPresetUsers();
 
@@ -119,19 +125,27 @@ describe('organization graphql test suite', () => {
     let adminOrg = {};
     const orgKeyName1 = 'orgKey1';
     const orgKeyName2 = 'orgKey2';
+    let orgKeyUuid0 = null;
     let orgKeyUuid1 = null;
     let orgKeyUuid2 = null;
+    let orgKeyVal1 = null;
+    let channel1Uuid = null;
+    let initialOrgKeyVersionUuid = null;
+    let remainingOrgKeyVersionUuid = null;
 
     it('a user should be able to get organizations associated with him.', async () => {
       try {
         token = await signInUser(models, api, user01Data);
 
-        const orgsResult = await api.organizations(token);
-        console.log(JSON.stringify(orgsResult.data));
-        expect(orgsResult.data.data.organizations).to.be.a('array');
-        expect(orgsResult.data.data.organizations.length).to.equal(1);
+        const response = await api.organizations(token);
+        console.log( `organizations (user01) response: ${JSON.stringify( response.data, null, 2 )}` );
+        if (response.data.errors) expect.fail(errors[0].message);
+        const organizations = response.data.data.organizations;
 
-        readerOrg = orgsResult.data.data.organizations[0];
+        expect(organizations).to.be.a('array');
+        expect(organizations.length).to.equal(1);
+
+        readerOrg = organizations[0];
         console.log( `readerOrg: ${JSON.stringify(readerOrg, null, 2)}` );
       } catch (error) {
         console.error('error response is ', error.response);
@@ -141,12 +155,15 @@ describe('organization graphql test suite', () => {
       try {
         token = await signInUser(models, api, rootData);
 
-        const orgsResult = await api.organizations(token);
-        console.log(JSON.stringify(orgsResult.data));
-        expect(orgsResult.data.data.organizations).to.be.a('array');
-        expect(orgsResult.data.data.organizations.length).to.equal(1);
+        const response = await api.organizations(token);
+        console.log( `organizations (admin) response: ${JSON.stringify( response.data, null, 2 )}` );
+        if (response.data.errors) expect.fail(errors[0].message);
+        const organizations = response.data.data.organizations;
 
-        adminOrg = orgsResult.data.data.organizations[0];
+        expect(organizations).to.be.a('array');
+        expect(organizations.length).to.equal(1);
+
+        adminOrg = organizations[0];
         console.log( `adminOrg: ${JSON.stringify(adminOrg, null, 2)}` );
       } catch (error) {
         console.error('error response is ', error.response);
@@ -155,23 +172,96 @@ describe('organization graphql test suite', () => {
       }
     });
 
+    it('an admin user should be able to list OrgKeys', async () => {
+      token = await signInUser(models, api, rootData);
+      try {
+        const response = await orgKeyApi.orgKeys(token, {
+          orgId: adminOrg.id
+        });
+        console.log( `orgKeys response: ${JSON.stringify( response.data, null, 2 )}` );
+        if (response.data.errors) expect.fail(errors[0].message);
+        const orgKeys = response.data.data.orgKeys;
+
+        expect(orgKeys).to.be.a('array');
+        expect(orgKeys.length).to.equal(1); // 1: original key only
+
+        orgKeyUuid0 = orgKeys[0].key;
+      } catch (error) {
+        if (error.response) {
+          console.error('error encountered:  ', error.response.data);
+        } else {
+          console.error('error encountered:  ', error);
+        }
+        throw error;
+      }
+    });
+
+    it('creating a new Version should encrypt with the initial OrgKey', async () => {
+      token = await signInUser(models, api, rootData);
+      try {
+        let response = await channelApi.addChannel(token, {
+          orgId: adminOrg.id,
+          name: 'a_random_name',
+          data_location: 'dal'
+        });
+        console.log( `addChannel 'a_random_name' response: ${JSON.stringify( response.data, null, 2 )}` );
+        if (response.data.errors) expect.fail(errors[0].message);
+        const addChannel = response.data.data.addChannel;
+
+        channel1Uuid = addChannel.uuid;
+
+        response = await channelApi.addChannelVersion(token, {
+          orgId: adminOrg.id,
+          channelUuid: channel1Uuid,
+          name: 'ver1-origOrgKey',
+          type: 'application/yaml',
+          content: '{"info": "This content encrypted with original OrgKey"}',
+          description: 'Version encrypted with origOrgKey'
+        });
+        console.log( `addChannelVersion 'ver1-origOrgKey' response: ${JSON.stringify( response.data, null, 2 )}` );
+        if (response.data.errors) expect.fail(errors[0].message);
+        const addChannelVersion = response.data.data.addChannelVersion;
+
+        expect(addChannelVersion.success).to.equal(true);
+        initialOrgKeyVersionUuid = addChannelVersion.versionUuid;
+
+        //Debug
+        const versions = await models.DeployableVersion.find({ uuid: initialOrgKeyVersionUuid}).lean();
+        console.log( `versions after creating initial: ${JSON.stringify( versions, null, 2 )}` );
+      } catch (error) {
+        if (error.response) {
+          console.error('error encountered:  ', error.response.data);
+        } else {
+          console.error('error encountered:  ', error);
+        }
+        throw error;
+      }
+    });
+
     it('an admin user should be able to add an OrgKey', async () => {
       token = await signInUser(models, api, rootData);
       try {
         console.log( `adding ${orgKeyName1} to '${adminOrg.id}'` );
-        const {
-          data: {
-            data: { addOrgKey },
-          },
-        } = await orgKeyApi.addOrgKey(token, {
+        const response = await orgKeyApi.addOrgKey(token, {
           orgId: adminOrg.id,
           name: orgKeyName1,
           primary: true
         });
+        console.log( `addOrgKey '${orgKeyName1}' response: ${JSON.stringify( response.data, null, 2 )}` );
+        if (response.data.errors) expect.fail(errors[0].message);
+        const addOrgKey = response.data.data.addOrgKey;
         expect(addOrgKey.uuid).to.be.an('string');
 
         orgKeyUuid1 = addOrgKey.uuid;
         console.log( `orgKeyUuid1: ${orgKeyUuid1}` );
+
+        // Allow time for async re-encryption.
+        // Ideally tests would verify old orgkey deletion fails as expected while re-encryption is in process, but it will usually finish faster than the next test can execute even without a delay.
+        await sleep(1000);
+
+        //Debug
+        const versions = await models.DeployableVersion.find({ uuid: initialOrgKeyVersionUuid}).lean();
+        console.log( `versions after creating new orgkey: ${JSON.stringify( versions, null, 2 )}` );
       } catch (error) {
         if (error.response) {
           console.error('error encountered:  ', error.response.data);
@@ -186,19 +276,26 @@ describe('organization graphql test suite', () => {
       token = await signInUser(models, api, rootData);
       try {
         console.log( `adding ${orgKeyName2} to '${adminOrg.id}'` );
-        const {
-          data: {
-            data: { addOrgKey },
-          },
-        } = await orgKeyApi.addOrgKey(token, {
+        const response = await orgKeyApi.addOrgKey(token, {
           orgId: adminOrg.id,
           name: orgKeyName2,
           primary: true
         });
+        console.log( `addOrgKey '${orgKeyName2}' response: ${JSON.stringify( response.data, null, 2 )}` );
+        if (response.data.errors) expect.fail(errors[0].message);
+        const addOrgKey = response.data.data.addOrgKey;
         expect(addOrgKey.uuid).to.be.an('string');
 
         orgKeyUuid2 = addOrgKey.uuid;
         console.log( `orgKeyUuid2: ${orgKeyUuid2}` );
+
+        // Allow time for async re-encryption.
+        // Ideally tests would verify old orgkey deletion fails as expected while re-encryption is in process, but it will usually finish faster than the next test can execute even without a delay.
+        await sleep(1000);
+
+        //Debug
+        const versions = await models.DeployableVersion.find({ uuid: initialOrgKeyVersionUuid}).lean();
+        console.log( `versions after creating new orgkey 2: ${JSON.stringify( versions, null, 2 )}` );
       } catch (error) {
         if (error.response) {
           console.error('error encountered:  ', error.response.data);
@@ -209,18 +306,18 @@ describe('organization graphql test suite', () => {
       }
     });
 
-    it('an admin user should be able to list OrgKeys', async () => {
+    it('an admin user should be able to list OrgKeys and see added keys', async () => {
       token = await signInUser(models, api, rootData);
       try {
-        const {
-          data: {
-            data: { orgKeys },
-          },
-        } = await orgKeyApi.orgKeys(token, {
+        const response = await orgKeyApi.orgKeys(token, {
           orgId: adminOrg.id
         });
+        console.log( `orgKeys response: ${JSON.stringify( response.data, null, 2 )}` );
+        if (response.data.errors) expect.fail(errors[0].message);
+        const orgKeys = response.data.data.orgKeys;
+
         expect(orgKeys).to.be.a('array');
-        expect(orgKeys.length).to.equal(3); // 3: original apikey plus the two just added
+        expect(orgKeys.length).to.equal(3); // 3: original key plus the two just added
       } catch (error) {
         if (error.response) {
           console.error('error encountered:  ', error.response.data);
@@ -234,19 +331,21 @@ describe('organization graphql test suite', () => {
     it('an admin user should be able to get an OrgKey by UUID', async () => {
       token = await signInUser(models, api, rootData);
       try {
-        const {
-          data: {
-            data: { orgKey },
-          },
-        } = await orgKeyApi.orgKey(token, {
+        const response = await orgKeyApi.orgKey(token, {
           orgId: adminOrg.id,
           uuid: orgKeyUuid1,
           name: null
         });
+        console.log( `orgKey '${orgKeyUuid1}' response: ${JSON.stringify( response.data, null, 2 )}` );
+        if (response.data.errors) expect.fail(errors[0].message);
+        const orgKey = response.data.data.orgKey;
+
         expect(orgKey.uuid).to.equal(orgKeyUuid1);
         expect(orgKey.name).to.equal(orgKeyName1);
         // Because second orgKey was created, second orgKey became 'primary'.  OrgKey1 should not be primary.
         expect(orgKey.primary).to.equal(false);
+
+        orgKeyVal1 = orgKey.key;
       } catch (error) {
         if (error.response) {
           console.error('error encountered:  ', error.response.data);
@@ -260,15 +359,15 @@ describe('organization graphql test suite', () => {
     it('an admin user should be able to get an OrgKey by Name', async () => {
       token = await signInUser(models, api, rootData);
       try {
-        const {
-          data: {
-            data: { orgKey },
-          },
-        } = await orgKeyApi.orgKey(token, {
+        const response = await orgKeyApi.orgKey(token, {
           orgId: adminOrg.id,
           uuid: null,
           name: orgKeyName2
         });
+        console.log( `orgKey '${orgKeyName2}' response: ${JSON.stringify( response.data, null, 2 )}` );
+        if (response.data.errors) expect.fail(errors[0].message);
+        const orgKey = response.data.data.orgKey;
+
         expect(orgKey.uuid).to.equal(orgKeyUuid2);
         expect(orgKey.name).to.equal(orgKeyName2);
         // Because second orgKey was created, second orgKey became 'primary'
@@ -286,18 +385,25 @@ describe('organization graphql test suite', () => {
     it('an admin user should be able to edit an OrgKey', async () => {
       token = await signInUser(models, api, rootData);
       try {
-        const {
-          data: {
-            data: { editOrgKey },
-          },
-        } = await orgKeyApi.editOrgKey(token, {
+        const response = await orgKeyApi.editOrgKey(token, {
           orgId: adminOrg.id,
           uuid: orgKeyUuid1,
           name: orgKeyName1+'_newname',
           primary: true
         });
-        console.log( `modified: ${JSON.stringify(editOrgKey)}` );
+        console.log( `editOrgKey '${orgKeyUuid1}' response: ${JSON.stringify( response.data, null, 2 )}` );
+        if (response.data.errors) expect.fail(errors[0].message);
+        const editOrgKey = response.data.data.editOrgKey;
+
         expect(editOrgKey.modified).to.equal(1);
+
+        // Allow time for async re-encryption.
+        // Ideally tests would verify old orgkey deletion fails as expected while re-encryption is in process, but it will usually finish faster than the next test can execute even without a delay.
+        await sleep(1000);
+
+        //Debug
+        const versions = await models.DeployableVersion.find({ uuid: initialOrgKeyVersionUuid}).lean();
+        console.log( `versions after editing orgkey1: ${JSON.stringify( versions, null, 2 )}` );
       } catch (error) {
         if (error.response) {
           console.error('error encountered:  ', error.response.data);
@@ -308,15 +414,15 @@ describe('organization graphql test suite', () => {
       }
       // Verify the change took effect
       try {
-        const {
-          data: {
-            data: { orgKey },
-          },
-        } = await orgKeyApi.orgKey(token, {
+        const response = await orgKeyApi.orgKey(token, {
           orgId: adminOrg.id,
           uuid: null,
           name: orgKeyName1+'_newname'
         });
+        console.log( `orgKey '${orgKeyName1+'_newname'}' response: ${JSON.stringify( response.data, null, 2 )}` );
+        if (response.data.errors) expect.fail(errors[0].message);
+        const orgKey = response.data.data.orgKey;
+
         expect(orgKey.uuid).to.equal(orgKeyUuid1);
         expect(orgKey.name).to.equal(orgKeyName1+'_newname');
         // OrgKey1 is now primary again, and OrgKey2 is not
@@ -331,18 +437,49 @@ describe('organization graphql test suite', () => {
       }
     });
 
-    it('an admin user should be able to remove a non-Primary OrgKey', async () => {
+    it('an admin user should be able to remove the initial OrgKey', async () => {
       token = await signInUser(models, api, rootData);
       try {
         console.log( `removing ${orgKeyUuid2} from '${adminOrg.id}'` );
-        const {
-          data: {
-            data: { removeOrgKey },
-          },
-        } = await orgKeyApi.removeOrgKey(token, {
+        const response = await orgKeyApi.removeOrgKey(token, {
+          orgId: adminOrg.id,
+          uuid: orgKeyUuid0
+        });
+        console.log( `removeOrgKey '${orgKeyUuid0}' response: ${JSON.stringify( response.data, null, 2 )}` );
+        if (response.data.errors) expect.fail(errors[0].message);
+        const removeOrgKey = response.data.data.removeOrgKey;
+
+        expect(removeOrgKey.success).to.equal(true);
+
+        //Debug
+        const versions = await models.DeployableVersion.find({ uuid: initialOrgKeyVersionUuid}).lean();
+        console.log( `versions after deleting orgkey0: ${JSON.stringify( versions, null, 2 )}` );
+      } catch (error) {
+        if (error.response) {
+          console.error('error encountered:  ', error.response.data);
+        } else {
+          console.error('error encountered:  ', error);
+        }
+        throw error;
+      }
+    });
+
+    it('an admin user should be able to remove a non-Primary OrgKey', async () => {
+      token = await signInUser(models, api, rootData);
+      try {
+        //Debug
+        const versions = await models.DeployableVersion.find({ uuid: initialOrgKeyVersionUuid}).lean();
+        console.log( `versions before deleting orgkey2 (${orgKeyUuid2}): ${JSON.stringify( versions, null, 2 )}` );
+
+        console.log( `removing ${orgKeyUuid2} from '${adminOrg.id}'` );
+        const response = await orgKeyApi.removeOrgKey(token, {
           orgId: adminOrg.id,
           uuid: orgKeyUuid2
         });
+        console.log( `removeOrgKey '${orgKeyUuid2}' response: ${JSON.stringify( response.data, null, 2 )}` );
+        if (response.data.errors) expect.fail(errors[0].message);
+        const removeOrgKey = response.data.data.removeOrgKey;
+
         expect(removeOrgKey.success).to.equal(true);
       } catch (error) {
         if (error.response) {
@@ -362,6 +499,7 @@ describe('organization graphql test suite', () => {
           orgId: adminOrg.id,
           uuid: orgKeyUuid1
         });
+
         expect(response.data.errors).to.exist;
       } catch (error) {
         if (error.response) {
@@ -372,20 +510,19 @@ describe('organization graphql test suite', () => {
         throw error;
       }
     });
-    it('an admin user SHOULD be able to remove a Primary OrgKey with forceDeletion', async () => {
+
+    it('an admin user should NOT be able to remove an OrgKey if it is the last one', async () => {
       token = await signInUser(models, api, rootData);
       try {
         console.log( `removing ${orgKeyUuid1} from '${adminOrg.id}' with forceDeletion` );
-        const {
-          data: {
-            data: { removeOrgKey },
-          },
-        } = await orgKeyApi.removeOrgKey(token, {
+        const response = await orgKeyApi.removeOrgKey(token, {
           orgId: adminOrg.id,
           uuid: orgKeyUuid1,
           forceDeletion: true
         });
-        expect(removeOrgKey.success).to.equal(true);
+        console.log( `removeOrgKey '${orgKeyUuid1}' response: ${JSON.stringify( response.data, null, 2 )}` );
+
+        expect(response.data.errors).to.exist;
       } catch (error) {
         if (error.response) {
           console.error('error encountered:  ', error.response.data);
@@ -395,5 +532,86 @@ describe('organization graphql test suite', () => {
         throw error;
       }
     });
+
+    it('registering a Cluster should return URL containing the remaining new OrgKey', async () => {
+      token = await signInUser(models, api, rootData);
+      try {
+        const response = await clusterApi.registerCluster(token, {
+          orgId: adminOrg.id,
+          registration: { name: 'newOrgKeyCluster' },
+        });
+        console.log( `registerCluster 'newOrgKeyCluster' response: ${JSON.stringify( response.data, null, 2 )}` );
+        if (response.data.errors) expect.fail(errors[0].message);
+        const registerCluster = response.data.data.registerCluster;
+
+        expect(registerCluster.url).to.be.an('string');
+        expect(registerCluster.url).contains(orgKeyVal1);
+      } catch (error) {
+        if (error.response) {
+          console.error('error encountered:  ', error.response.data);
+        } else {
+          console.error('error encountered:  ', error);
+        }
+        throw error;
+      }
+    });
+
+    it('creating a new Version should encrypt with the remaining OrgKey', async () => {
+      token = await signInUser(models, api, rootData);
+      try {
+        const response = await channelApi.addChannelVersion(token, {
+          orgId: adminOrg.id,
+          channelUuid: channel1Uuid,
+          name: 'ver2-remainingOrgKey',
+          type: 'application/yaml',
+          content: '{"info": "This content encrypted with remaining OrgKey"}',
+          description: 'Version encrypted with remainingOrgKey'
+        });
+        console.log( `addChannelVersion 'ver2-remainingOrgKey' response: ${JSON.stringify( response.data, null, 2 )}` );
+        if (response.data.errors) expect.fail(errors[0].message);
+        const addChannelVersion = response.data.data.addChannelVersion;
+
+        expect(addChannelVersion.success).to.equal(true);
+        remainingOrgKeyVersionUuid = addChannelVersion.versionUuid;
+      } catch (error) {
+        if (error.response) {
+          console.error('error encountered:  ', error.response.data);
+        } else {
+          console.error('error encountered:  ', error);
+        }
+        throw error;
+      }
+    });
+
+    it('debug all versions', async () => {
+      token = await signInUser(models, api, rootData);
+      try {
+        // Get all Versions from the DB
+        const versions = await models.DeployableVersion.find({}).lean();
+        console.log( `versions: ${JSON.stringify( versions, null, 2 )}` );
+
+        // For each version, get via API and verify contents are retrieved and decrypted correctly eventhough they were originally encrypted by different keys
+        for( const v of versions ) {
+          const response = await channelApi.channelVersion(token, {
+            orgId: adminOrg.id,
+            channelUuid: channel1Uuid,
+            versionUuid: v.uuid,
+          });
+          console.log( `version '${v.uuid} response': ${JSON.stringify( response.data, null, 2 )}` );
+          if (response.data.errors) expect.fail(errors[0].message);
+          const channelVersion = response.data.data.channelVersion;
+
+          expect(channelVersion.content).to.contain('This content encrypted with');
+        }
+      } catch (error) {
+        if (error.response) {
+          console.error('error encountered:  ', error.response.data);
+        } else {
+          console.error('error encountered:  ', error);
+        }
+        throw error;
+      }
+    });
+
   });
 });

--- a/app/apollo/utils/versionUtils.js
+++ b/app/apollo/utils/versionUtils.js
@@ -1,0 +1,293 @@
+/**
+ * Copyright 2022 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const storageFactory = require('../../storage/storageFactory');
+const { getOrgKeyByUuid, bestOrgKey } = require('../../utils/orgs');
+const { whoIs } = require ('../resolvers/common');
+const conf = require('../../conf.js').conf;
+
+const getDecryptedContent = async ( context, org, version ) => {
+  const { me, req_id, logger } = context;
+  const logContext = { req_id, user: whoIs(me), orgId: org.uuid, version: version.uuid, methodName: 'getDecryptedContent' };
+
+  const handler = storageFactory(logger).deserialize(version.content);
+
+  const retVal = {};
+
+  try {
+    retVal.encryptionOrgKeyUuid = version.desiredOrgKeyUuid || org.orgKeys[0];
+    const orgKey = getOrgKeyByUuid( org, retVal.encryptionOrgKeyUuid );
+    retVal.content = await handler.getDataAndDecrypt(orgKey.key, version.iv);
+    logger.info(logContext, `successfully decrypted version '${version.uuid}' with desiredOrgKeyUuid for request ${req_id}`);
+  }
+  catch( decryptError1 ) {
+    try {
+      retVal.encryptionOrgKeyUuid = version.verifiedOrgKeyUuid || org.orgKeys[0];
+      const orgKey = getOrgKeyByUuid( org, retVal.encryptionOrgKeyUuid );
+      retVal.content = await handler.getDataAndDecrypt(orgKey.key, version.iv);
+      logger.info(logContext, `successfully decrypted version '${version.uuid}' with verifiedOrgKeyUuid for request ${req_id}`);
+    }
+    catch( decryptError2 ) {
+      logContext.error = decryptError2.message;
+      logger.error(logContext, `encountered an error when decrypting version '${version.uuid}' with verifiedOrgKeyUuid for request ${req_id}: ${decryptError2.message}`);
+      throw decryptError2;
+    }
+  }
+
+  return retVal;
+};
+
+const updateVersionKeys = async ( context, org, version, desiredOrgKeyUuid, verifiedOrgKeyUuid, newData ) => {
+  const { models, me, req_id, logger } = context;
+  const logContext = { req_id, user: whoIs(me), orgId: org.uuid, version: version.uuid, methodName: 'updateVersionKeys' };
+  logger.info( logContext, `Entry, desiredOrgKeyUuid: ${desiredOrgKeyUuid}, verifiedOrgKeyUuid: ${verifiedOrgKeyUuid}, org._id: ${org._id}, version: ${version.uuid}` );
+
+  if( desiredOrgKeyUuid ) {
+    const retVal = await models.DeployableVersion.updateOne(
+      {
+        org_id: org._id,
+        uuid: version.uuid,
+        $and: [
+          {$or: [ { verifiedOrgKeyUuid: { $exists: false } }, { verifiedOrgKeyUuid: version.verifiedOrgKeyUuid } ]},
+          {$or: [ { desiredOrgKeyUuid: { $exists: false } }, { desiredOrgKeyUuid: version.desiredOrgKeyUuid } ]}
+        ]
+      },
+      { $set: { verifiedOrgKeyUuid: verifiedOrgKeyUuid, desiredOrgKeyUuid: desiredOrgKeyUuid } }
+    );
+    return retVal;
+  }
+  else {
+    const retVal = await models.DeployableVersion.updateOne(
+      {
+        org_id: org._id,
+        uuid: version.uuid
+      },
+      { $set: { verifiedOrgKeyUuid: verifiedOrgKeyUuid, content: newData.data } }
+    );
+    return retVal;
+  }
+};
+
+/*
+If storing for the first time, 'channel' must be provided so that data location can be determined.
+If overwriting existing data, 'channel' is not used and data location, bucket, path etc are read from the 'version'.
+*/
+const encryptAndStore = async ( context, org, channel, version, orgKey, content ) => {
+  const { me, req_id, logger } = context;
+  const logContext = { req_id, user: whoIs(me), orgId: org.uuid, version: version.uuid, methodName: 'encryptAndStore' };
+
+  /*
+  More concise but fails linting:
+  const path = version?.content?.data?.path || `${org._id.toLowerCase()}-${version.channel_id}-${version.uuid}`;
+  const dataLocation = version?.content?.data?.location || channel?.data_location;
+  const bucketName = version?.content?.data?.bucketName || conf.storage.getChannelBucket(dataLocation);
+  */
+  const path = (version.content && version.content.data && version.content.data.path) ? version.content.data.path : `${org._id.toLowerCase()}-${version.channel_id}-${version.uuid}`;
+  const dataLocation = (version.content && version.content.data && version.content.data.location) ? version.content.data.location : (channel ? channel.data_location : null);
+  const bucketName = (version.content && version.content.data && version.content.data.bucketName) ? version.content.data.bucketName : conf.storage.getChannelBucket(dataLocation);
+
+  const handler = storageFactory(logger).newResourceHandler(path, bucketName, dataLocation);
+  await handler.setDataAndEncrypt(content, orgKey.key);
+  logger.info( logContext, `${(version.content && version.content.data) ? 'created object' : 'overwrote object'}, bucketName: ${bucketName}, path: ${path}` );
+  const data = handler.serialize();
+  return( {data} );
+};
+
+// Keep track of which orgs are updating version encryption to avoid repeated re-encryption.
+// This also serves to throttle repeated calls that could cause excess load by repeatedly re-encrypting.
+const orgsUpdatingVersionEncryption = {};
+
+/*
+Update all Versions to use the newOrgKey for encryption.
+Each Version tracks which OrgKey is currently used for encryption (verifiedOrgKeyUuid) and which OrgKey it is being re-encrypted with (desiredOrgKeyUuid).
+If execution is terminated during the re-encryption, one of these two will still be valid and ensures that decryption is always possible.
+
+Return object indicating how many Versions were successfully re-encrypted, how many failed to re-encrypt, and how many were not attempted.
+*/
+const updateAllVersionEncryption = async (context, org, versions, newOrgKey) => {
+  const retVal = { successful: 0, failed: 0, incomplete: versions.length };
+
+  const updatingOrgKey = orgsUpdatingVersionEncryption[ org._id ];
+  if( updatingOrgKey == newOrgKey.orgKeyUuid ) {
+    // Updating the encryption to use the newOrgKey is already in process.
+    throw new Error( 'already in progress' );
+  }
+  orgsUpdatingVersionEncryption[ org._id ] = newOrgKey.orgKeyUuid;
+
+  for( const v of versions ) {
+    try {
+      const result = await updateVersionEncryption( context, org, v, newOrgKey);
+      if( result ) {
+        // This version reencrypted successfully (or no-op), continue
+        retVal.successful++;
+        retVal.incomplete--;
+      }
+      else {
+        // Version re-encryption should halt now!
+        return( retVal );
+      }
+    }
+    catch( e ) {
+      // This Version did not re-encrypte successfully due to an error (e.g. unable to communicate with the database or unable to decrypt existing data)
+      // Re-encryption can continue.
+      retVal.failed++;
+      retVal.incomplete--;
+    }
+  }
+  delete orgsUpdatingVersionEncryption[ org._id ];
+  return( retVal );
+};
+
+/*
+Return true if Version re-encryption succeeded and re-encryption should continue.
+Return false if Version re-encryption should halt and re-encryption of this Version was not attempted.
+Throw an error if unable to re-encrypt.  Re-encryption should continue however.
+*/
+const updateVersionEncryption = async (context, org, version, newOrgKey) => {
+  const { me, req_id, logger, models } = context;
+  const logContext = { req_id, user: whoIs(me), orgId: org.uuid, version: version.uuid, orgKey: newOrgKey.orgKeyUuid, methodName: 'updateVersionEncryption' };
+  logger.info( logContext, 'Entry' );
+
+  // Re-retrieve the Org from the DB
+  try {
+    org = await models.Organization.findById(org._id);
+    const currentBestOrgKey = bestOrgKey( org );
+    if( currentBestOrgKey.orgKeyUuid != newOrgKey.orgKeyUuid ) {
+      // If the newOrgKey is no longer the best OrgKey, abort.
+      // This could occur if another OrgKey is created before re-encryption finishes.
+      logger.info( logContext, 'Best OrgKey has changed.  Aborting.' );
+      return false;
+    }
+  }
+  catch( e ) {
+    // If unable to determine if the newOrgKey is still the best OrgKey, abort.
+    logContext.error = e.message;
+    logger.error( logContext, 'Error while confirming best OrgKey.  Aborting.' );
+    return false;
+  }
+
+  let encryptionOrgKeyUuid, content;
+  try {
+    const decryptResult = await getDecryptedContent( context, org, version );  // This func tries `desiredOrgKeyUuid` first, falls back to `verifiedOrgKeyUuid`, then fails if neither work.
+    encryptionOrgKeyUuid = decryptResult.encryptionOrgKeyUuid;
+    content = decryptResult.content;
+  }
+  catch( e ) {
+    // It could not be retrieved or could not be decrypted, something has gone wrong!
+    // E.g. someone/something force-deleting an OrgKey such that data encrypted with it cannot be retrieved.
+    logContext.error = e.message;
+    logger.error( logContext, 'Unable to retrieve existing Version content' );
+    throw( e );
+  }
+  logger.info( logContext, `Existing Version contents decrypted successfully, encryption OrgKey: ${encryptionOrgKeyUuid}` );
+
+  if( version.desiredOrgKeyUuid != newOrgKey.orgKeyUuid || version.verifiedOrgKeyUuid != newOrgKey.orgKeyUuid ) {
+    // Version is not using the new OrgKey as BOTH `verifiedOrgKeyUuid` and `desiredOrgKeyUuid`.
+    // Either way, the Version needs to be updated to set working OrgKey as `verifiedOrgKeyUuid` and the new OrgKey as `desiredOrgKeyUuid`.
+    try {
+      const result = await updateVersionKeys( context, org, version, newOrgKey.orgKeyUuid, encryptionOrgKeyUuid );
+      logger.info( logContext, `Version key update result: ${JSON.stringify(result)}` );
+      if( result.matchedCount != 1 ) {
+        // Version update did not occur because another process was updating the Version record in parallel (changing used keys or deleting it).
+        // Re-encryption did not occur but the Version still has the OrgKey that is known to decrypt successfully in either `verifiedOrgKeyUuid` or `desiredOrgKeyUuid`.
+        // Additional future calls to this function can attempt re-encryption, and Version content retrieval will continue to work.
+        logger.warn( logContext, `Simultaneous updates to Version '${version.uuid}' detected, unable to update encryption safely.  Continuing.` );
+        return( true );
+      }
+    }
+    catch( e ) {
+      // Error communicating with database, throw
+      logContext.error = e.message;
+      logger.error( logContext, 'Error ocurred while updating Version keys.  Continuing.' );
+      throw e;
+    }
+    logger.info( logContext, 'Version keys update started, re-encrypting content next...' );
+    // After updating the Version record with `verifiedOrgKeyUuid` and `desiredOrgKeyUuid`, continue and re-encrypt with new OrgKey if needed.
+  }
+
+  if( encryptionOrgKeyUuid == newOrgKey.orgKeyUuid ) {
+    // Version is already able to decrypt with the newOrgKey
+    // Version uses newOrgKey as `verifiedOrgKeyUuid` (if not already set, was set above)
+    // Version uses newOrgKey as `desiredOrgKeyUuid` (if not already set, was set above)
+    // No re-encryption needed
+    logger.info( logContext, 'Encryption is already up to date.  Continuing.' );
+    return( true );
+  }
+  else {
+    // Version is not able to decrypt with the newOrgKey (though the newOrgKey is now set as the `desiredOrgKeyUuid`, the _actual_ working OrgKey is set as `verifiedOrgKeyUuid`)
+    // Re-encryption needed
+    let newData;
+    try {
+      // For re-encryption, the Version contains all the data storage info needed (bucket name, data location, path for S3), so channel is passed as 'null'.
+      newData = await encryptAndStore( context, org, null, version, newOrgKey, content );
+
+      /*
+      Dev Note:
+      The `encryptAndStore` function name is a misnomer.  It uses `setDataAndEncrypt` on the appropriate storage handler.
+      However the storage handler behavior is inconsistent:
+        - embeddedResourceHandler does not actually *store/set* the data, it returns the new data and relies on the calling function to persist the value into the database in the Version's `content` attribute.
+        - s3ResourceHandler *does* actually store the data into an S3 bucket before returning, and the return value from the function is only needed the first time the database record is written (it does not change on re-encryption).
+      I.e. when re-encrypting an embedded resource, the newData must be saved in updateVersionKeys below, but it does not need to be saved (the values wont change) when re-encrypting an S3 resource.
+      */
+    }
+    catch( e ) {
+      // Re-encryption did not occur (e.g. error writing to S3) but the Version still has the OrgKey that is known to decrypt successfully in `verifiedOrgKeyUuid`.
+      // Additional future calls to this function will attempt to rectify this again, but Version content retrieval will continue to work in the mean time.
+      logContext.error = e.message;
+      logger.error( logContext, 'Error during data re-encryption.  Continuing.' );
+      throw e;
+    }
+    logger.info( logContext, 'Version content re-encrypted successfully, updating version keys next...' );
+
+    /*
+    Before 'updateVersionEncryption' was introduced, the iv (initialization vector) would be stored separately from the encrypted data, in the db record.
+    This is problematic for re-encryption as any data reads _between_ storing the re-encrypted data and storing the iv in the db record will use incorrect iv and result in garbled response (not an exception).
+    If the code happens to _exit for any reason_ between storing the encrypted data and updating the db record (e.g. crash, pod eviction, etc), the iv is permanently lost and the data permanently garbled.
+    Initial version creation doesn't have this problem only because it writes the encrypted data first and then creates the Version record with the iv -- the data cannot be read before the Version record is created.
+
+    To address this problem and allow re-encrypting the data, all new encrypted data and re-encrypted data will store the iv along with the encrypted data.
+
+    Alternative solutions considered include:
+    - All new encryption / re-encryptionUse a different algorithm that doesn't rely on 'iv' text, such as 'AES'.  If unable to decrypt with old algorithm, fall back to 'AES'.
+    - New data storage to actually *de*-encrypt and store plaintext.  If unable to decrypt with old algorithm, fall back to returning plaintext.
+    */
+
+    // After re-encrypting, update the Version to reflect the new `verifiedOrgKeyUuid`
+    try {
+      const result = await updateVersionKeys( context, org, version, null, newOrgKey.orgKeyUuid, newData );
+      if( result.matchedCount != 1 ) {
+        // Version update did not occur because another process deleted it in parallel.
+        logger.warn( logContext, `Version '${version.uuid}' no longer exists when attempting final key update.` );
+      }
+    }
+    catch( e ) {
+      // Error communicating with database, throw
+      logContext.error = e.message;
+      logger.error( logContext, 'Error during final Version key update.  Continuing.' );
+      throw e;
+    }
+
+    // Version updates and re-encryption successful (or no-op)
+    logger.info( logContext, 'Version key updates and re-encryption successful (or no-op).  Continuing.' );
+    return( true );
+  }
+};
+
+module.exports = {
+  getDecryptedContent,
+  encryptAndStore,
+  updateAllVersionEncryption,
+};

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -93,7 +93,7 @@ router.use(async (req, res, next) => {
   req.orgKey = orgKey;
   const log = req.log;
   const orgDb = req.db.collection('orgs');
-  const org = await orgDb.findOne( { $or: [ { orgKeys: orgKey }, { orgKeys2.key: orgKey } ] } );
+  const org = await orgDb.findOne( { $or: [ { orgKeys: orgKey }, { 'orgKeys2.key': orgKey } ] } );
   if (org) log.fields.org_id = org._id;
   next();
 });

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -93,7 +93,7 @@ router.use(async (req, res, next) => {
   req.orgKey = orgKey;
   const log = req.log;
   const orgDb = req.db.collection('orgs');
-  const org = await orgDb.findOne({ orgKeys: orgKey });
+  const org = await orgDb.findOne( { $or: [ { orgKeys: orgKey }, { orgKeys2.key: orgKey } ] } );
   if (org) log.fields.org_id = org._id;
   next();
 });

--- a/app/routes/v1/systemSubscriptions.js
+++ b/app/routes/v1/systemSubscriptions.js
@@ -17,7 +17,7 @@
 const express = require('express');
 const router = express.Router();
 const asyncHandler = require('express-async-handler');
-const { getOrg, bestOrgKeyValue } = require('../../utils/orgs');
+const { getOrg, bestOrgKey } = require('../../utils/orgs');
 
 /*
 Serves a System Subscription that regenerates the `razee-identity` secret with the 'best' OrgKey value.
@@ -32,7 +32,7 @@ metadata:
     razee/watch-resource: lite
     addonmanager.kubernetes.io/mode: Reconcile
 data:
-  RAZEE_ORG_KEY: ${Buffer.from( bestOrgKeyValue( req.org ) ).toString('base64')}
+  RAZEE_ORG_KEY: ${Buffer.from( bestOrgKey( req.org ).key ).toString('base64')}
 type: Opaque
 `;
 

--- a/app/storage/s3ResourceHandler.js
+++ b/app/storage/s3ResourceHandler.js
@@ -19,6 +19,7 @@
 const conf = require('./../conf.js').conf;
 const S3ClientClass = require('./s3NewClient');
 const cipher = require('./cipher');
+const iv_delim = ' ';
 
 class S3ResourceHandler {
 
@@ -53,11 +54,12 @@ class S3ResourceHandler {
   }
 
   async setDataAndEncrypt(stringOrBuffer, key) {
-    this.logInfo(`Uploading object ${this.bucketName}:${this.resourceKey} ...`);
+    this.logInfo(`Uploading encrypted object ${this.bucketName}:${this.resourceKey} ...`);
     const { encryptedBuffer, ivText } = cipher.encrypt(stringOrBuffer, key);
-    const result = await this.s3NewClient.upload(this.bucketName, this.resourceKey, encryptedBuffer);
-    this.logInfo(`Uploaded object to ${result.Location}`);
-    return ivText;
+    const ivBuffer = Buffer.from( ivText+iv_delim, 'utf8' );
+    const s_combinedBuffer = Buffer.concat( [ivBuffer, encryptedBuffer] );
+    const result = await this.s3NewClient.upload(this.bucketName, this.resourceKey, s_combinedBuffer);
+    this.logInfo(`Uploaded encrypted object to ${result.Location}`);
   }
 
   async setData(stringOrBuffer) {
@@ -66,11 +68,22 @@ class S3ResourceHandler {
     this.logInfo(`Uploaded object to ${result.Location}`);
   }
 
+  // If data embeds iv, ignore passed iv (passed iv only for legacy data)
   async getDataAndDecrypt(key, iv) {
     this.logInfo(`Downloading object ${this.bucketName}:${this.resourceKey} ...`);
     const response = await this.s3NewClient.getObject(this.bucketName, this.resourceKey);
     const encryptedBuffer = Buffer.from(response.Body);
-    return cipher.decryptBuffer(encryptedBuffer, key, iv); // utf-8 text
+
+    const delimIdx = encryptedBuffer.indexOf( iv_delim, 0, 'utf8' );
+    // If iv is embedded, first 24 bytes are the embedded iv.  The rest of the buffer is the delimiter and the encrypted content, which will be multiples of 8 bytes.
+    if( delimIdx == 24 && encryptedBuffer.length % 8 == iv_delim.length ) {
+      this.logInfo( `retrieved buffer (len: ${encryptedBuffer.length}) embeds iv` );
+      let s_iv = encryptedBuffer.subarray(0,delimIdx).toString('utf8');
+      const s_encryptedBuffer = encryptedBuffer.subarray( delimIdx + iv_delim.length );
+      return cipher.decryptBuffer(s_encryptedBuffer, key, s_iv); // utf-8 text
+    }
+    this.logInfo( `retrieved buffer (len: ${encryptedBuffer.length}) does not embed iv` );
+    return cipher.decryptBuffer(encryptedBuffer, key, iv);
   }
 
   async getData() {

--- a/app/utils/orgs.js
+++ b/app/utils/orgs.js
@@ -72,20 +72,45 @@ const decryptOrgData = (orgKey, data) => {
 Best OrgKey value is:
 - First found OrgKeys2 key marked as Primary
 - First found OrgKeys2 key if no Primary identified
-- First OrgKeys OrgKey if no OrgKeys2 exist
+- First OrgKeys if no OrgKeys2 exist
 */
-const bestOrgKeyValue = (org) => {
+const bestOrgKey = (org) => {
   if( org.orgKeys2 && org.orgKeys2.length > 0 ) {
     const bestOrgKey = org.orgKeys2.find( o => {
       return( o.primary );
     } );
-    return( bestOrgKey.key || org.orgKeys2[0].key );
+    return( bestOrgKey || org.orgKeys2[0] );
   }
   else if( org.orgKeys && org.orgKeys.length > 0 ) {
-    return( org.orgKeys[0] );
+    return( getLegacyOrgKeyObject( org.orgKeys[0] ) );
   }
 
   throw new Error( `No valid OrgKey found for organization ${org._id}` );
 };
+const getLegacyOrgKeyObject = (legacyOrgKey) => {
+  return( {
+    orgKeyUuid: legacyOrgKey,
+    name: legacyOrgKey.slice( legacyOrgKey.length - 12 ),  // last segment of legacy key, which is essentially a UUID prefixed by `orgApiKey-`
+    primary: false,
+    created: null,
+    updated: null,
+    key: legacyOrgKey
+  } );
+};
+const getOrgKeyByUuid = (org, uuid) => {
+  if( org.orgKeys2 ) {
+    const orgKey = org.orgKeys2.find( o => {
+      return( o.orgKeyUuid == uuid );
+    } );
+    if( orgKey ) return( orgKey );
+  }
 
-module.exports = { getOrg, verifyAdminOrgKey, encryptOrgData, decryptOrgData, bestOrgKeyValue };
+  if( org.orgKeys ) {
+    const index = org.orgKeys.indexOf( uuid );
+    if( index >= 0 ) return getLegacyOrgKeyObject( org.orgKeys[index] );
+  }
+
+  throw new Error( `OrgKey '${uuid}' not found for organization ${org._id}` );
+};
+
+module.exports = { getOrg, verifyAdminOrgKey, encryptOrgData, decryptOrgData, bestOrgKey, getOrgKeyByUuid, getLegacyOrgKeyObject };

--- a/app/utils/orgs.tests.js
+++ b/app/utils/orgs.tests.js
@@ -19,7 +19,7 @@ const mongodb = require('mongo-mock');
 const httpMocks = require('node-mocks-http');
 const { log } = require('../log');
 
-const { getOrg, verifyAdminOrgKey, bestOrgKeyValue } = require('./orgs');
+const { getOrg, verifyAdminOrgKey, bestOrgKey } = require('./orgs');
 
 let db = {};
 
@@ -206,8 +206,8 @@ describe('utils', () => {
         ]
       };
 
-      const bestOrgKey = bestOrgKeyValue( testOrg );
-      assert.equal(bestOrgKey, 'bestKey');
+      const orgKey = bestOrgKey( testOrg ).key;
+      assert.equal(orgKey, 'bestKey');
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,22 @@
       "resolved": "https://registry.npmjs.org/@apollo/utils.dropunuseddefinitions/-/utils.dropunuseddefinitions-1.1.0.tgz",
       "integrity": "sha512-jU1XjMr6ec9pPoL+BFWzEPW7VHHulVdGKMkPAMiCigpVIT11VmCbnij0bWob8uS3ODJ65tZLYKAh/55vLw2rbg=="
     },
+    "@apollo/utils.keyvaluecache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-1.0.1.tgz",
+      "integrity": "sha512-nLgYLomqjVimEzQ4cdvVQkcryi970NDvcRVPfd0OPeXhBfda38WjBq+WhQFk+czSHrmrSp34YHBxpat0EtiowA==",
+      "requires": {
+        "@apollo/utils.logger": "^1.0.0",
+        "lru-cache": "^7.10.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "7.14.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.0.tgz",
+          "integrity": "sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ=="
+        }
+      }
+    },
     "@apollo/utils.logger": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-1.0.0.tgz",
@@ -464,14 +480,44 @@
       }
     },
     "@graphql-tools/mock": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/mock/-/mock-8.6.12.tgz",
-      "integrity": "sha512-o4plehiIgwqIB3TJDlEx7s6CHucTnrYsv4LqBXfyiXN10E9x0Ab44UxXjePbAd9yJFYEUYp0thqb7WjI3/3cmQ==",
+      "version": "8.7.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/mock/-/mock-8.7.4.tgz",
+      "integrity": "sha512-fLZglFyD/nkejYtPZ0vZLe8zqi0TL/SMgEz715Ir/Kr7zpmczQD1t8Wn3o1jzi58q8dQnvGTWxdt5tM0a5Tm4g==",
       "requires": {
-        "@graphql-tools/schema": "8.3.14",
-        "@graphql-tools/utils": "8.6.13",
+        "@graphql-tools/schema": "9.0.2",
+        "@graphql-tools/utils": "8.10.1",
         "fast-json-stable-stringify": "^2.1.0",
         "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "@graphql-tools/merge": {
+          "version": "8.3.4",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.4.tgz",
+          "integrity": "sha512-2z1UpHvvI52nQZIYArU+rPq1lOENWetsdb+6vu8yLGyCRP4CpKMBvtmiHkbrlPBO8dItpZ08szXEoaStfJHBxQ==",
+          "requires": {
+            "@graphql-tools/utils": "8.10.1",
+            "tslib": "^2.4.0"
+          }
+        },
+        "@graphql-tools/schema": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.2.tgz",
+          "integrity": "sha512-FnBM1PMKQ6y8KlzeFocnEwcGA/IT++z4v+hvvwwXL+IUYDNqmrp9XYNklpQRb/KKSbTtKnQapCWNiVNex7jl+Q==",
+          "requires": {
+            "@graphql-tools/merge": "8.3.4",
+            "@graphql-tools/utils": "8.10.1",
+            "tslib": "^2.4.0",
+            "value-or-promise": "1.0.11"
+          }
+        },
+        "@graphql-tools/utils": {
+          "version": "8.10.1",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.10.1.tgz",
+          "integrity": "sha512-UYi/afPvxZ8mz0LjplMxOSmGDPenVS/Q0zJ/6LOyF9yZdJYIDe+J+Qr/I9+rCYQmgBW4BJeRUUc7VoUzZPfZDA==",
+          "requires": {
+            "tslib": "^2.4.0"
+          }
+        }
       }
     },
     "@graphql-tools/schema": {
@@ -1325,22 +1371,14 @@
       }
     },
     "apollo-datasource": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-3.3.1.tgz",
-      "integrity": "sha512-Z3a8rEUXVPIZ1p8xrFL8bcNhWmhOmovgDArvwIwmJOBnh093ZpRfO+ESJEDAN4KswmyzCLDAwjsW4zQOONdRUw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-3.3.2.tgz",
+      "integrity": "sha512-L5TiS8E2Hn/Yz7SSnWIVbZw0ZfEIXZCa5VUiVxD9P53JvSrf4aStvsFDlGWPvpIdCR+aly2CfoB79B9/JjKFqg==",
       "requires": {
-        "apollo-server-caching": "^3.3.0",
+        "@apollo/utils.keyvaluecache": "^1.0.1",
         "apollo-server-env": "^4.2.1"
       },
       "dependencies": {
-        "apollo-server-caching": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-3.3.0.tgz",
-          "integrity": "sha512-Wgcb0ArjZ5DjQ7ID+tvxUcZ7Yxdbk5l1MxZL8D8gkyjooOkhPNzjRVQ7ubPoXqO54PrOMOTm1ejVhsF+AfIirQ==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
         "apollo-server-env": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-4.2.1.tgz",
@@ -1407,10 +1445,11 @@
       }
     },
     "apollo-server-core": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.8.2.tgz",
-      "integrity": "sha512-cbzG928HG27W+juMVCIL1O//iyAj/Q2hnOu6YwrGrcqeE75ZIJSgSBm/gPHK20cI7nEjK2IWACx8Hj1nGAQ5Zg==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.10.2.tgz",
+      "integrity": "sha512-/1o9KPoAMgcjJJ9Y0IH1665wf9d02L/m/mcfBOHiFmRgeGkNgrhTy59BxQTBK241USAWMhwMpp171cv/hM5Dng==",
       "requires": {
+        "@apollo/utils.keyvaluecache": "^1.0.1",
         "@apollo/utils.logger": "^1.0.0",
         "@apollo/utils.usagereporting": "^1.0.0",
         "@apollographql/apollo-tools": "^0.5.3",
@@ -1418,13 +1457,12 @@
         "@graphql-tools/mock": "^8.1.2",
         "@graphql-tools/schema": "^8.0.0",
         "@josephg/resolvable": "^1.0.0",
-        "apollo-datasource": "^3.3.1",
-        "apollo-reporting-protobuf": "^3.3.1",
-        "apollo-server-caching": "^3.3.0",
+        "apollo-datasource": "^3.3.2",
+        "apollo-reporting-protobuf": "^3.3.2",
         "apollo-server-env": "^4.2.1",
         "apollo-server-errors": "^3.3.1",
-        "apollo-server-plugin-base": "^3.6.0",
-        "apollo-server-types": "^3.6.0",
+        "apollo-server-plugin-base": "^3.6.2",
+        "apollo-server-types": "^3.6.2",
         "async-retry": "^1.2.1",
         "fast-json-stable-stringify": "^2.1.0",
         "graphql-tag": "^2.11.0",
@@ -1435,17 +1473,37 @@
         "whatwg-mimetype": "^3.0.0"
       },
       "dependencies": {
+        "@apollo/protobufjs": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.4.tgz",
+          "integrity": "sha512-npVJ9NVU/pynj+SCU+fambvTneJDyCnif738DnZ7pCxdDtzeEz7WkpSIq5wNUmWm5Td55N+S2xfqZ+WP4hDLng==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/long": "^4.0.0",
+            "@types/node": "^10.1.0",
+            "long": "^4.0.0"
+          }
+        },
         "@apollographql/apollo-tools": {
           "version": "0.5.4",
           "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.5.4.tgz",
           "integrity": "sha512-shM3q7rUbNyXVVRkQJQseXv6bnYM3BUma/eZhwXR4xsuM+bqWnJKvW7SAfRjP7LuSCocrexa5AXhjjawNHrIlw=="
         },
-        "apollo-server-caching": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-3.3.0.tgz",
-          "integrity": "sha512-Wgcb0ArjZ5DjQ7ID+tvxUcZ7Yxdbk5l1MxZL8D8gkyjooOkhPNzjRVQ7ubPoXqO54PrOMOTm1ejVhsF+AfIirQ==",
+        "apollo-reporting-protobuf": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-3.3.2.tgz",
+          "integrity": "sha512-j1tx9tmkVdsLt1UPzBrvz90PdjAeKW157WxGn+aXlnnGfVjZLIRXX3x5t1NWtXvB7rVaAsLLILLtDHW382TSoQ==",
           "requires": {
-            "lru-cache": "^6.0.0"
+            "@apollo/protobufjs": "1.2.4"
           }
         },
         "apollo-server-env": {
@@ -1457,21 +1515,21 @@
           }
         },
         "apollo-server-plugin-base": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.6.0.tgz",
-          "integrity": "sha512-GtXhczRGpTLQyFPWeWSnX1VcN2JaaAU7WT8PzoTQuJKYJ/Aj5mPebHbfG+PXQlDmI8IgyCKf7B1HIRnJqvAZbg==",
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.6.2.tgz",
+          "integrity": "sha512-erWXjLOO1u7fxQkbxJ2cwSO7p0tYzNied91I1SJ9tikXZ/2eZUyDyvrpI+4g70kOdEi+AmJ5Fo8ahEXKJ75zdg==",
           "requires": {
-            "apollo-server-types": "^3.6.0"
+            "apollo-server-types": "^3.6.2"
           }
         },
         "apollo-server-types": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.6.0.tgz",
-          "integrity": "sha512-zISCkwXvwTHK2AysWSfLAUvDLSDJ0xj8pnfxDv34hqA+G9JqsLbykJdSL1Y1kT53HU4RWF6ymTuTwwOmmBiAWA==",
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.6.2.tgz",
+          "integrity": "sha512-9Z54S7NB+qW1VV+kmiqwU2Q6jxWfX89HlSGCGOo3zrkrperh85LrzABgN9S92+qyeHYd72noMDg2aI039sF3dg==",
           "requires": {
+            "@apollo/utils.keyvaluecache": "^1.0.1",
             "@apollo/utils.logger": "^1.0.0",
-            "apollo-reporting-protobuf": "^3.3.1",
-            "apollo-server-caching": "^3.3.0",
+            "apollo-reporting-protobuf": "^3.3.2",
             "apollo-server-env": "^4.2.1"
           }
         }
@@ -12975,9 +13033,9 @@
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xss": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.13.tgz",
-      "integrity": "sha512-clu7dxTm1e8Mo5fz3n/oW3UCXBfV89xZ72jM8yzo1vR/pIS0w3sgB3XV2H8Vm6zfGnHL0FzvLJPJEBhd86/z4Q==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.14.tgz",
+      "integrity": "sha512-og7TEJhXvn1a7kzZGQ7ETjdQVS2UfZyTlsEdDOqvQF7GoxNfY+0YLCzBy1kPdsDDx4QuNAonQPddpsn6Xl/7sw==",
       "requires": {
         "commander": "^2.20.3",
         "cssfilter": "0.0.10"


### PR DESCRIPTION
Re-try changes for handling encryption when rotating OrgKeys.  Primary differences:
- Fixed a couple bugs where legacy orgKeys was still assumed
- Significantly more unit tests for orgkey rotation and verification of re-encryption