### PR TITLE
ensure version does not need to change when editing subscription

### DIFF
--- a/app/apollo/resolvers/subscription.js
+++ b/app/apollo/resolvers/subscription.js
@@ -457,6 +457,8 @@ const subscriptionResolvers = {
         }
 
         const oldVersionUuid = subscription.version_uuid;
+        // If neither version_uuid or version specified, keep the prior version (i.e. set version_uuid)
+        if( !version && !version_uuid ) version_uuid = oldVersionUuid;
 
         await validAuth(me, orgId, ACTIONS.UPDATE, TYPES.SUBSCRIPTION, queryName, context, [subscription.uuid, subscription.name]);
 

--- a/app/apollo/resolvers/subscription.js
+++ b/app/apollo/resolvers/subscription.js
@@ -457,8 +457,8 @@ const subscriptionResolvers = {
         }
 
         const oldVersionUuid = subscription.version_uuid;
-        // If neither version_uuid or version specified, keep the prior version (i.e. set version_uuid)
-        if( !version && !version_uuid ) version_uuid = oldVersionUuid;
+        // If neither new version or version_uuid specified, keep the prior version (i.e. set version_uuid)
+        if( !newVersion && !version_uuid ) version_uuid = oldVersionUuid;
 
         await validAuth(me, orgId, ACTIONS.UPDATE, TYPES.SUBSCRIPTION, queryName, context, [subscription.uuid, subscription.name]);
 


### PR DESCRIPTION
With experimental feature to allow specifying a version object (new version) instead of an existing version_uuid, some safety checking is needed in case a user specifies neither.  In this case, keep referencing the existing version uuid