### PR TITLE
correct handling of experimental arguments and testing

### DIFF
--- a/app/apollo/resolvers/channel.js
+++ b/app/apollo/resolvers/channel.js
@@ -542,9 +542,6 @@ const channelResolvers = {
         if( subscriptions.length > 0 ) {
           throw new RazeeValidationError( context.req.t( 'Unsupported arguments: [{{args}}]', { args: 'subscriptions' } ), context );
         }
-
-        // Note this feature is not full implemented, see commented out code later in this function.
-        throw new RazeeValidationError( context.req.t( 'Unsupported arguments: [{{args}}]', { args: 'subscriptions' } ), context );
       }
 
       // Validate new version
@@ -648,6 +645,11 @@ const channelResolvers = {
           if( subscriptions ) {
             throw new RazeeValidationError( context.req.t( 'Unsupported arguments: [{{args}}]', { args: 'subscriptions' } ), context );
           }
+        }
+        // Block experimental feature even if enabled as it's not fully implemented
+        if( subscriptions ) {
+          // Note this feature is not full implemented, see commented out code later in this function.  Block even if experimental flag is enabled.
+          throw new RazeeValidationError( context.req.t( 'Unsupported arguments: [{{args}}]', { args: 'subscriptions' } ), context );
         }
 
         const version = await models.DeployableVersion.findOne( { uuid, org_id } );
@@ -850,7 +852,7 @@ const channelResolvers = {
 
       try{
         // Experimental
-        if( !process.env.EXPERIMENTAL_GITOPS ) {
+        if( !process.env.EXPERIMENTAL_GITOPS_ALT ) {
           // Block experimental features
           if( deleteSubscriptions ) {
             throw new RazeeValidationError( context.req.t( 'Unsupported arguments: [{{args}}]', { args: 'deleteSubscriptions' } ), context );

--- a/app/apollo/test/channel.remote.spec.js
+++ b/app/apollo/test/channel.remote.spec.js
@@ -101,8 +101,10 @@ const createClusters = async () => {
 
 describe('channel remote graphql test suite', () => {
   before(async () => {
+    console.log( 'Setting EXPERIMENTAL env vars' ); // IMPORTANT: Must be deleted in 'after()' to avoid impacting other tests that do not expect these vars to be set.
     process.env.EXPERIMENTAL_GITOPS = 'true';
     process.env.EXPERIMENTAL_GITOPS_ALT = 'true';
+
     mongoServer = new MongoMemoryServer( { binary: { version: '4.2.17' } } );
     await mongoServer.start();
     const mongoUrl = mongoServer.getUri();
@@ -124,6 +126,10 @@ describe('channel remote graphql test suite', () => {
   after(async () => {
     await myApollo.stop(myApollo);
     await mongoServer.stop();
+
+    console.log( 'Deleting EXPERIMENTAL env vars' );
+    delete process.env.EXPERIMENTAL_GITOPS;
+    delete process.env.EXPERIMENTAL_GITOPS_ALT;
   }); // after
 
   it('block remote Channels if EXPERIMENTAL_GITOPS not set', async () => {
@@ -696,8 +702,6 @@ describe('channel remote graphql test suite', () => {
       throw error;
     }
   });
-
-
 
   it('add a subscription and version under the remote channel', async () => {
     try {


### PR DESCRIPTION
Fixes two bugs:
- experimental code incorrectly checked and blocked `subscriptions` arg
- automated tests incorrectly did not unset the experimental mode, allowing the first bug to be unnoticed by following tests (which were still running in experimental mode)