### PR TITLE
Prevent groupLimit from causing data loss in cluster queries

### DIFF
--- a/app/apollo/schema/common.js
+++ b/app/apollo/schema/common.js
@@ -1,9 +1,10 @@
+// groupLimit is no longer used, will always return all groups
 var globalGraphqlInputs = `
   mongoQueries: MongoQueries
-  
+
   resourceLimit: Int = 500
-  groupLimit: Int = 16
-  
+  groupLimit: Int = -1
+
 `;
 
 module.exports =  {

--- a/app/apollo/test/cluster.spec.js
+++ b/app/apollo/test/cluster.spec.js
@@ -695,7 +695,7 @@ describe('cluster graphql test suite', () => {
       });
 
       expect(inactiveClusters2).to.be.an('array');
-      expect(inactiveClusters2).to.have.length(1);
+      expect(inactiveClusters2).to.have.length(3);
       expect(inactiveClusters2[0].clusterId).to.equal('cluster_04');
       expect(inactiveClusters2[0].groups).to.have.length(1);
 

--- a/app/apollo/test/cluster.spec.js
+++ b/app/apollo/test/cluster.spec.js
@@ -376,15 +376,15 @@ describe('cluster graphql test suite', () => {
       expect(clusterByClusterId.lastOrgKey.uuid).to.equal(org_01_orgkey);
 
 
-      //with group limit
+      //with group limit (groupLimit is no longer used, will always return all groups)
       const result2 = await clusterApi.byClusterID(token, {
         orgId: org01._id,
         clusterId: clusterId1,
         groupLimit: 2,
       });
       const clusterByClusterId2 = result2.data.data.clusterByClusterId;
-      expect(clusterByClusterId2.groups).to.have.length(2);
-      expect(clusterByClusterId2.groupObjs).to.have.length(2);
+      expect(clusterByClusterId2.groups).to.have.length(3);
+      expect(clusterByClusterId2.groupObjs).to.have.length(3);
       expect(clusterByClusterId2.clusterId).to.equal(clusterId1);
 
     } catch (error) {
@@ -459,7 +459,7 @@ describe('cluster graphql test suite', () => {
       const skipLimitedClustersByOrgId2 = skipResponse2.data.data.clustersByOrgId;
       expect(skipLimitedClustersByOrgId2).to.have.length(0);
 
-      // with group limit
+      // with group limit (groupLimit is no longer used, will always return all groups)
       const {
         data: {
           data: { clustersByOrgId: clustersByOrgId2 },
@@ -469,8 +469,8 @@ describe('cluster graphql test suite', () => {
         groupLimit: 2,
       });
 
-      expect(clustersByOrgId2[3].groupObjs).to.have.length(2);
-      expect(clustersByOrgId2[3].groups).to.have.length(2);
+      expect(clustersByOrgId2[3].groupObjs).to.have.length(3);
+      expect(clustersByOrgId2[3].groups).to.have.length(3);
       expect(clustersByOrgId2).to.be.an('array');
       expect(clustersByOrgId2).to.have.length(4);
       expect(clustersByOrgId2[0].resources).to.be.an('array');
@@ -601,7 +601,7 @@ describe('cluster graphql test suite', () => {
       expect(clusterSearch).to.be.an('array');
       expect(clusterSearch).to.have.length(4);
 
-      // with group limit
+      // with group limit (groupLimit is no longer used, will always return all groups)
       const {
         data: {
           data: { clusterSearch:  clusterSearch2},
@@ -611,8 +611,8 @@ describe('cluster graphql test suite', () => {
         groupLimit: 2,
       });
 
-      expect(clusterSearch2[3].groupObjs).to.have.length(2);
-      expect(clusterSearch2[3].groups).to.have.length(2);
+      expect(clusterSearch2[3].groupObjs).to.have.length(3);
+      expect(clusterSearch2[3].groups).to.have.length(3);
       expect(clusterSearch2).to.be.an('array');
       expect(clusterSearch2).to.have.length(4);
 
@@ -684,7 +684,7 @@ describe('cluster graphql test suite', () => {
       expect(inactiveClusters[0].clusterId).to.equal('cluster_04');
       expect(inactiveClusters[0].groups).to.have.length(3);
 
-      // with group filter
+      // with group filter (groupLimit is no longer used, will always return all groups)
       const {
         data: {
           data: { inactiveClusters: inactiveClusters2 },

--- a/app/apollo/test/cluster.spec.js
+++ b/app/apollo/test/cluster.spec.js
@@ -695,9 +695,9 @@ describe('cluster graphql test suite', () => {
       });
 
       expect(inactiveClusters2).to.be.an('array');
-      expect(inactiveClusters2).to.have.length(3);
+      expect(inactiveClusters2).to.have.length(1);
       expect(inactiveClusters2[0].clusterId).to.equal('cluster_04');
-      expect(inactiveClusters2[0].groups).to.have.length(1);
+      expect(inactiveClusters2[0].groups).to.have.length(3);
 
     } catch (error) {
       if (error.response) {

--- a/app/apollo/utils/applyQueryFields.js
+++ b/app/apollo/utils/applyQueryFields.js
@@ -35,7 +35,7 @@ const loadResourcesWithSearchAndArgs = async({ search, args, context })=>{
 
 const applyQueryFieldsToClusters = async(clusters, queryFields={}, args, context)=>{
   const { models } = context;
-  const { orgId, groupLimit } = args;
+  const { orgId } = args;
 
   const clusterIds = _.map(clusters, 'cluster_id');
   const now = new Date();
@@ -87,7 +87,16 @@ const applyQueryFieldsToClusters = async(clusters, queryFields={}, args, context
       //   {groups: [{name: 'tag2'}]},
       // ]
       const groupNames = _.filter(_.uniq(_.map(_.flatten(_.map(clusters, 'groups')), 'name')));
-      const groups = await models.Group.find({ org_id: orgId, name: { $in: groupNames } }).limit(groupLimit).lean({ virtuals: true });
+      /*
+      groupLimit is no longer used, will always return all groups
+      Prior to removing `limit(groupLimit)`, if more than groupLimit groups were present
+      in all the clusters being processed, some groups would be omitted and cut from the
+      respective cluster(s) without warning.  E.g. when querying clusterByOrgId (all
+      clusters) some clusters could return with fewer groups than they really have,
+      yet when querying each cluster individually (clusterByClusterId) their full
+      set of groups (up to groupLimit) would be included.
+      */
+      const groups = await models.Group.find({ org_id: orgId, name: { $in: groupNames } }).lean({ virtuals: true });
 
       await applyQueryFieldsToGroups(groups, queryFields.groupObjs, args, context);
 

--- a/local-dev/api/clusterGetByOrgId.sh
+++ b/local-dev/api/clusterGetByOrgId.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+RAZEE_ORG_ID=${4:-${RAZEE_ORG_ID:-pOrgId}}
+
+RAZEE_QUERY='query($orgId: String!) { clustersByOrgId( orgId: $orgId ) { orgId, clusterId, name, groups { uuid name } } }'
+RAZEE_VARIABLES='{"orgId":"'"${RAZEE_ORG_ID}"'"}'
+
+echo "" && echo "GET clusters by OrgId"
+${SCRIPT_DIR}/graphqlPost.sh "${RAZEE_QUERY}" "${RAZEE_VARIABLES}" | jq --color-output
+echo "Result: $?"

--- a/local-dev/api/introspect.sh
+++ b/local-dev/api/introspect.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+RAZEE_QUERY='query IntrospectionQuery{__schema{queryType{name}mutationType{name}subscriptionType{name}types{...FullType}directives{name description locations args{...InputValue}}}}fragment FullType on __Type{kind name description fields(includeDeprecated:true){name description args{...InputValue}type{...TypeRef}isDeprecated deprecationReason}inputFields{...InputValue}interfaces{...TypeRef}enumValues(includeDeprecated:true){name description isDeprecated deprecationReason}possibleTypes{...TypeRef}}fragment InputValue on __InputValue{name description type{...TypeRef}defaultValue}fragment TypeRef on __Type{kind name ofType{kind name ofType{kind name ofType{kind name ofType{kind name ofType{kind name ofType{kind name ofType{kind name}}}}}}}}'
+RAZEE_VARIABLES='{}'
+
+echo "" && echo "IntrospectionQuery"
+${SCRIPT_DIR}/graphqlPost.sh "${RAZEE_QUERY}" "${RAZEE_VARIABLES}" | jq --color-output
+echo "Result: $?"


### PR DESCRIPTION
Any time groupLimit (default 16) is exceeded, data will be cut from the response without warning.  E.g. querying clustersByOrgId will return all the clusters, but some will be randomly missing groups.  Querying a single cluster that is a member of more than groupLimit groups will return the cluster but with only groupLimit groups randomly included and the rest missing.  This is misleading.