### PR TITLE
allow idempotent registerCluster API behavior

### DIFF
--- a/app/apollo/models/cluster.js
+++ b/app/apollo/models/cluster.js
@@ -20,5 +20,4 @@ const mongooseLeanVirtuals = require('mongoose-lean-virtuals');
 
 ClusterSchema.plugin(mongooseLeanVirtuals);
 const Cluster = mongoose.model('clusters', ClusterSchema);
-
 module.exports = Cluster;

--- a/app/apollo/models/cluster.schema.js
+++ b/app/apollo/models/cluster.schema.js
@@ -125,6 +125,7 @@ const ClusterSchema = new mongoose.Schema({
 });
 
 ClusterSchema.index({ org_id: 1, cluster_id: 1 }, { unique: true });
+ClusterSchema.index({ org_id: 1, 'registration.name': 1 }, { unique: true });
 
 // Used to get cluster details for ServiceSubscriptions
 ClusterSchema.statics.getClustersByIds = async function(ids){

--- a/app/apollo/models/index.js
+++ b/app/apollo/models/index.js
@@ -28,6 +28,28 @@ const Group = require('./group');
 const fs = require('fs');
 const mongoConf = require('../../conf.js').conf;
 
+
+const indexUpdateHandler = (error) => {
+  if( error ) {
+    console.log( `indexUpdateHandler: Index update failed: ${error.message}` );
+  }
+  else {
+    console.log( `indexUpdateHandler: Index update successful` );
+  }
+};
+User.on( 'index', indexUpdateHandler );
+Resource.on( 'index', indexUpdateHandler );
+Cluster.on( 'index', indexUpdateHandler );
+Organization.on( 'index', indexUpdateHandler );
+Channel.on( 'index', indexUpdateHandler );
+Subscription.on( 'index', indexUpdateHandler );
+ServiceSubscription.on( 'index', indexUpdateHandler );
+DeployableVersion.on( 'index', indexUpdateHandler );
+ResourceYamlHist.on( 'index', indexUpdateHandler );
+Group.on( 'index', indexUpdateHandler );
+
+
+
 mongoose.Promise = global.Promise; // use global es6 promises
 
 

--- a/app/apollo/models/index.js
+++ b/app/apollo/models/index.js
@@ -34,7 +34,7 @@ const indexUpdateHandler = (error) => {
     console.log( `indexUpdateHandler: Index update failed: ${error.message}` );
   }
   else {
-    console.log( `indexUpdateHandler: Index update successful` );
+    console.log( 'indexUpdateHandler: Index update successful' );
   }
 };
 User.on( 'index', indexUpdateHandler );

--- a/app/apollo/schema/cluster.js
+++ b/app/apollo/schema/cluster.js
@@ -184,6 +184,7 @@ const clusterSchema = gql`
     registerCluster (
       orgId: String! @sv
       registration: JSON! @jv
+      idempotent: Boolean = false
     ): RegisterClusterResponse!
 
     """

--- a/app/apollo/test/cluster.spec.js
+++ b/app/apollo/test/cluster.spec.js
@@ -203,6 +203,7 @@ const createClusters = async () => {
         platform: 'linux/amd64',
       },
     },
+    registration: { name: 'my-cluster3' },
   });
 
   await models.Cluster.create({
@@ -223,6 +224,7 @@ const createClusters = async () => {
         platform: 'linux/amd64',
       },
     },
+    registration: { name: 'my-cluster4' },
   });
 
   // updated: new Moment().subtract(2, 'day').toDate(),
@@ -243,6 +245,7 @@ const createClusters = async () => {
         platform: 'linux/amd64',
       },
     },
+    registration: { name: 'my-clusterA' },
   });
 }; // create clusters
 
@@ -728,6 +731,7 @@ describe('cluster graphql test suite', () => {
             platform: 'linux/amd64',
           },
         },
+        registration: { name: 'testcluster-tobedeletedbyuser01' },
       });
 
       const data = await clusterApi.deleteClusterByClusterId(token, {
@@ -766,6 +770,7 @@ describe('cluster graphql test suite', () => {
             platform: 'linux/amd64',
           },
         },
+        registration: { name: 'testcluster-tobedeletedbyadmin' },
       });
 
       await models.Resource.create({
@@ -823,6 +828,7 @@ describe('cluster graphql test suite', () => {
             platform: 'linux/amd64',
           },
         },
+        registration: { name: 'testcluster-tobedeletedbyadmin' },
       });
 
       await models.Resource.create({
@@ -865,6 +871,7 @@ describe('cluster graphql test suite', () => {
         orgId: org01._id,
         registration: { name: 'my-cluster123' },
       });
+      console.log( `response: ${JSON.stringify( registerCluster.data, null, 2 )}` );
       expect(registerCluster.data.data.registerCluster.url).to.be.an('string');
 
       const result = await clusterApi.byClusterName(token, {
@@ -901,7 +908,25 @@ describe('cluster graphql test suite', () => {
     }
   });
 
-
+  it('try to ensure the registration of cluster with the same name', async () => {
+    try {
+      const result = await clusterApi.registerCluster(adminToken, {
+        orgId: org01._id,
+        registration: { name: 'my-cluster123' },
+        idempotent: true,
+      });
+      console.log( `result: ${JSON.stringify( result.data, null, 2 )}` );
+      expect(result.data.data.registerCluster.url).to.be.an('string');
+      //expect(registerCluster.data.errors[0].message).to.contain('Another cluster already exists with the same registration name');
+    } catch (error) {
+      if (error.response) {
+        console.error('error encountered:  ', error.response.data);
+      } else {
+        console.error('error encountered:  ', error);
+      }
+      throw error;
+    }
+  });
 
   it('try to register a cluster when max # of clusters per account is reached', async () => {
     try {
@@ -1011,6 +1036,7 @@ describe('cluster graphql test suite', () => {
             platform: 'linux/amd64',
           },
         },
+        registration: { name: 'testcluster-enableregurl' },
       });
 
       const {

--- a/app/apollo/test/clusterApi.js
+++ b/app/apollo/test/clusterApi.js
@@ -375,8 +375,8 @@ const clusterFunc = grahqlUrl => {
       grahqlUrl,
       {
         query: `
-          mutation($orgId: String!,$registration: JSON!) {
-            registerCluster(orgId: $orgId registration: $registration) {
+          mutation($orgId: String!, $registration: JSON!, $idempotent: Boolean) {
+            registerCluster(orgId: $orgId, registration: $registration, idempotent: $idempotent) {
               url
           }
         }

--- a/app/apollo/test/group.spec.js
+++ b/app/apollo/test/group.spec.js
@@ -197,6 +197,7 @@ const createClusters = async () => {
         platform: 'linux/amd64',
       },
     },
+    registration: { name: 'mycluster-1' },
   });
 
   await models.Cluster.create({
@@ -215,6 +216,7 @@ const createClusters = async () => {
         platform: 'linux/amd64',
       },
     },
+    registration: { name: 'mycluster-2' },
   });
 
   await models.Cluster.create({
@@ -233,6 +235,7 @@ const createClusters = async () => {
         platform: 'linux/amd64',
       },
     },
+    registration: { name: 'mycluster-3' },
   });
 
   await models.Cluster.create({
@@ -253,6 +256,7 @@ const createClusters = async () => {
         platform: 'linux/amd64',
       },
     },
+    registration: { name: 'mycluster-4' },
   });
 
   // updated: new Moment().subtract(2, 'day').toDate(),
@@ -273,6 +277,7 @@ const createClusters = async () => {
         platform: 'linux/amd64',
       },
     },
+    registration: { name: 'mycluster-A' },
   });
 }; // create clusters
 

--- a/app/apollo/test/resource.spec.js
+++ b/app/apollo/test/resource.spec.js
@@ -102,6 +102,7 @@ const createClusters = async () => {
         platform: 'linux/amd64',
       },
     },
+    registration: { name: 'any-cluster-1' },
   });
   await models.Cluster.create({
     org_id:  org_01._id,
@@ -119,6 +120,7 @@ const createClusters = async () => {
         platform: 'linux/amd64',
       },
     },
+    registration: { name: 'mycluster-1' },
   });
   await models.Cluster.create({
     org_id:  org_01._id,
@@ -136,6 +138,7 @@ const createClusters = async () => {
         platform: 'linux/amd64',
       },
     },
+    registration: { name: 'mycluster-3' },
   });
   await models.Cluster.create({
     org_id:  org_02._id,
@@ -153,6 +156,7 @@ const createClusters = async () => {
         platform: 'linux/amd64',
       },
     },
+    registration: { name: 'mycluster-4' },
   });
 };
 const createSubscriptions = async () => {
@@ -364,7 +368,7 @@ describe('resource graphql test suite', () => {
           '/mybla/selfLink',
         );
         expect(result1.data.data.resources.resources[0].cluster.clusterId).to.equal('cluster_01');
-        expect(result1.data.data.resources.resources[0].cluster.name).to.equal('cluster_01');
+        expect(result1.data.data.resources.resources[0].cluster.name).to.equal('mycluster-1');
 
         const { id } = result1.data.data.resources.resources[0];
         const result2 = await api.resource(token, { orgId: meResult.data.data.me.orgId, id: id.toString() });

--- a/app/apollo/test/subscriptions.default.spec.js
+++ b/app/apollo/test/subscriptions.default.spec.js
@@ -99,6 +99,7 @@ const createClusters = async () => {
         platform: 'linux/amd64',
       },
     },
+    registration: { name: 'mycluster-1' },
   });
   await models.Cluster.create({
     org_id: org01._id,
@@ -122,6 +123,7 @@ const createClusters = async () => {
         platform: 'linux/amd64',
       },
     },
+    registration: { name: 'mycluster-2' },
   });
 };
 


### PR DESCRIPTION
allow idempotent registerCluster API behavior (i.e. if registerCluster GQL request submitted multiple times for the same cluster, all will return with the normal successful response rather than an 'already exists' error).  This can be used by automation to retry cluster registration until success, without needing to differentiate between 'already exists' and other failures.