### PR TITLE
make GQL error handling and responses more consistent

### DIFF
--- a/app/apollo/resolvers/cluster.js
+++ b/app/apollo/resolvers/cluster.js
@@ -126,9 +126,13 @@ const clusterResolvers = {
         await applyQueryFieldsToClusters([cluster], queryFields, args, context);
 
         return cluster;
-      } catch (error) {
-        logger.error({req_id, user, org_id, clusterId, error } , `${queryName} error encountered: ${error.message}`);
-        throw error;
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        if (error instanceof BasicRazeeError || error instanceof ValidationError) {
+          throw error;
+        }
+        throw new RazeeQueryError(context.req.t('Query {{queryName}} error. MessageID: {{req_id}}.', {'queryName':queryName, 'req_id':req_id}), context);
       }
     }, // end cluster by _id
 
@@ -187,9 +191,13 @@ const clusterResolvers = {
         await applyQueryFieldsToClusters([cluster], queryFields, args, context);
 
         return cluster;
-      } catch (error) {
-        logger.error({req_id, user, org_id, clusterName, error } , `${queryName} error encountered: ${error.message}`);
-        throw error;
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        if (error instanceof BasicRazeeError || error instanceof ValidationError) {
+          throw error;
+        }
+        throw new RazeeQueryError(context.req.t('Query {{queryName}} error. MessageID: {{req_id}}.', {'queryName':queryName, 'req_id':req_id}), context);
       }
     }, // end clusterByClusterName
 
@@ -238,9 +246,13 @@ const clusterResolvers = {
         await applyQueryFieldsToClusters(clusters, queryFields, args, context);
 
         return clusters;
-      } catch (error) {
-        logger.error({req_id, user, org_id, error } , `${queryName} error encountered: ${error.message}`);
-        throw error;
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        if (error instanceof BasicRazeeError || error instanceof ValidationError) {
+          throw error;
+        }
+        throw new RazeeQueryError(context.req.t('Query {{queryName}} error. MessageID: {{req_id}}.', {'queryName':queryName, 'req_id':req_id}), context);
       }
     }, // end clustersByOrgId
 
@@ -276,9 +288,13 @@ const clusterResolvers = {
         await applyQueryFieldsToClusters(clusters, queryFields, args, context);
 
         return clusters;
-      } catch (error) {
-        logger.error({req_id, user, org_id, error } , `${queryName} error encountered: ${error.message}`);
-        throw error;
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        if (error instanceof BasicRazeeError || error instanceof ValidationError) {
+          throw error;
+        }
+        throw new RazeeQueryError(context.req.t('Query {{queryName}} error. MessageID: {{req_id}}.', {'queryName':queryName, 'req_id':req_id}), context);
       }
     }, // end inactiveClusters
 
@@ -334,9 +350,13 @@ const clusterResolvers = {
         await applyQueryFieldsToClusters(clusters, queryFields, args, context);
 
         return clusters;
-      } catch (error) {
-        logger.error({req_id, user, org_id, error } , `${queryName} error encountered: ${error.message}`);
-        throw error;
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        if (error instanceof BasicRazeeError || error instanceof ValidationError) {
+          throw error;
+        }
+        throw new RazeeQueryError(context.req.t('Query {{queryName}} error. MessageID: {{req_id}}.', {'queryName':queryName, 'req_id':req_id}), context);
       }
     }, // end clusterSearch
 
@@ -380,9 +400,13 @@ const clusterResolvers = {
 
         for (const item of results){ item.id = item._id; }
         return results;
-      } catch (error) {
-        logger.error({req_id, user, org_id, error } , `${queryName} error encountered: ${error.message}`);
-        throw error;
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        if (error instanceof BasicRazeeError || error instanceof ValidationError) {
+          throw error;
+        }
+        throw new RazeeQueryError(context.req.t('Query {{queryName}} error. MessageID: {{req_id}}.', {'queryName':queryName, 'req_id':req_id}), context);
       }
     }, // end clusterCountByKubeVersion
   }, // end query
@@ -441,9 +465,13 @@ const clusterResolvers = {
           deletedServiceSubscriptionCount: deletedServiceSubscription.deletedCount,
           url: await getCleanupUrl( org_id, context ),
         };
-      } catch (error) {
-        logger.error({req_id, user, org_id, cluster_id, error } , `${queryName} error encountered: ${error.message}`);
-        throw new RazeeQueryError(context.req.t('Query {{queryName}} error. {{error.message}}', {'queryName':queryName, 'error.message':error.message}), context);
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        if (error instanceof BasicRazeeError || error instanceof ValidationError) {
+          throw error;
+        }
+        throw new RazeeQueryError(context.req.t('Query {{queryName}} error. MessageID: {{req_id}}.', {'queryName':queryName, 'req_id':req_id}), context);
       }
     }, // end delete cluster by org_id and cluster_id
 
@@ -504,9 +532,13 @@ const clusterResolvers = {
           deletedServiceSubscriptionCount: deletedServiceSubscription.deletedCount,
           url: await getCleanupUrl( org_id, context ),
         };
-      } catch (error) {
-        logger.error({req_id, user, org_id, error } , `${queryName} error encountered: ${error.message}`);
-        throw new RazeeQueryError(context.req.t('Query {{queryName}} error. {{error.message}}', {'queryName':queryName, 'error.message':error.message}), context);
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        if (error instanceof BasicRazeeError || error instanceof ValidationError) {
+          throw error;
+        }
+        throw new RazeeQueryError(context.req.t('Query {{queryName}} error. MessageID: {{req_id}}.', {'queryName':queryName, 'req_id':req_id}), context);
       }
     }, // end delete cluster by org_id
 
@@ -602,14 +634,13 @@ const clusterResolvers = {
 
         logger.info({req_id, user, org_id, registration, cluster_id}, `${queryName} returning`);
         return { url, orgId: org_id, clusterId: cluster_id, orgKey: bestOrgKey( org ).key, regState: reg_state, registration };
-      } catch (error) {
-        logger.error({ req_id, user, org_id, registration, error }, `${queryName} error encountered: ${error.message}`);
-
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }
-        // Note: mongo/mongoose errors will not have a 'message' attribute, look like: { index: 0, code: 11000, keyPattern: ....}
-        throw new RazeeQueryError(context.req.t('Query {{queryName}} error. {{error.message}}', {'queryName':queryName, 'error.message':error.message || `code ${error.code}`}), context);
+        throw new RazeeQueryError(context.req.t('Query {{queryName}} error. MessageID: {{req_id}}.', {'queryName':queryName, 'req_id':req_id}), context);
       }
     }, // end registerCluster
 
@@ -652,9 +683,13 @@ const clusterResolvers = {
           logger.info({ req_id, user, org_id, cluster_id }, `${queryName} returning (no update)`);
           return null;
         }
-      } catch (error) {
-        logger.error({ req_id, user, org_id, cluster_id, error }, `${queryName} error encountered: ${error.message}`);
-        throw new RazeeQueryError(context.req.t('Query {{queryName}} error. {{error.message}}', {'queryName':queryName, 'error.message':error.message}), context);
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        if (error instanceof BasicRazeeError || error instanceof ValidationError) {
+          throw error;
+        }
+        throw new RazeeQueryError(context.req.t('Query {{queryName}} error. MessageID: {{req_id}}.', {'queryName':queryName, 'req_id':req_id}), context);
       }
     }, // end enableRegistrationUrl
   }

--- a/app/apollo/resolvers/group.js
+++ b/app/apollo/resolvers/group.js
@@ -51,9 +51,13 @@ const groupResolvers = {
         await applyQueryFieldsToGroups(groups, queryFields, { orgId: org_id }, context);
 
         return groups;
-      } catch (error) {
-        logger.error({req_id, user, org_id, error } , `${queryName} error encountered: ${error.message}`);
-        throw error;
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        if (error instanceof BasicRazeeError || error instanceof ValidationError) {
+          throw error;
+        }
+        throw new RazeeQueryError(context.req.t('Query {{queryName}} error. MessageID: {{req_id}}.', {'queryName':queryName, 'req_id':req_id}), context);
       }
     },
     group: async(parent, { orgId: org_id, uuid }, context, fullQuery) => {
@@ -77,9 +81,13 @@ const groupResolvers = {
         await applyQueryFieldsToGroups([group], queryFields, { orgId: org_id }, context);
 
         return group;
-      } catch (error) {
-        logger.error({req_id, user, org_id, uuid, error } , `${queryName} error encountered: ${error.message}`);
-        throw error;
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        if (error instanceof BasicRazeeError || error instanceof ValidationError) {
+          throw error;
+        }
+        throw new RazeeQueryError(context.req.t('Query {{queryName}} error. MessageID: {{req_id}}.', {'queryName':queryName, 'req_id':req_id}), context);
       }
     },
     groupByName: async(parent, { orgId: org_id, name }, context, fullQuery) => {
@@ -111,9 +119,13 @@ const groupResolvers = {
         await applyQueryFieldsToGroups([group], queryFields, { orgId: org_id }, context);
 
         return group;
-      } catch (error) {
-        logger.error({req_id, user, org_id, name } , `${queryName} error encountered: ${error.message}`);
-        throw error;
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        if (error instanceof BasicRazeeError || error instanceof ValidationError) {
+          throw error;
+        }
+        throw new RazeeQueryError(context.req.t('Query {{queryName}} error. MessageID: {{req_id}}.', {'queryName':queryName, 'req_id':req_id}), context);
       }
     },
   },
@@ -155,8 +167,9 @@ const groupResolvers = {
         return {
           uuid,
         };
-      } catch (error) {
-        logger.error({ req_id, user, org_id, name, error }, `${queryName} error encountered: ${error.message}`);
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }
@@ -208,8 +221,9 @@ const groupResolvers = {
           uuid: group.uuid,
           success: true,
         };
-      } catch (error) {
-        logger.error({ req_id, user, org_id, uuid, error }, `${queryName} error encountered: ${error.message}`);
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }
@@ -274,8 +288,9 @@ const groupResolvers = {
           uuid: group.uuid,
           success: true,
         };
-      } catch (error) {
-        logger.error({ req_id, user, org_id, name, error }, `${queryName} error encountered: ${error.message}`);
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }
@@ -376,8 +391,9 @@ const groupResolvers = {
         return {
           modified: res.modifiedCount
         };
-      } catch (error) {
-        logger.error({ req_id, user, org_id, groupUuids, clusterIds, error }, `${queryName} error encountered: ${error.message}`);
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }
@@ -447,8 +463,9 @@ const groupResolvers = {
         return {
           modified: res.modifiedCount
         };
-      } catch (error) {
-        logger.error({ req_id, user, org_id, groupUuids, clusterIds, error }, `${queryName} error encountered: ${error.message}`);
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }
@@ -525,8 +542,9 @@ const groupResolvers = {
         return {
           modified: res.modifiedCount
         };
-      } catch (error) {
-        logger.error({ req_id, user, org_id, groupUuids, clusterId, error }, `${queryName} error encountered: ${error.message}`);
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }
@@ -587,8 +605,9 @@ const groupResolvers = {
 
         logger.info({ req_id, user, org_id, uuid, clusters }, `${queryName} returning`);
         return {modified: res.modifiedCount };
-      } catch (error) {
-        logger.error({ req_id, user, org_id, uuid, clusters, error }, `${queryName} error encountered: ${error.message}`);
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }
@@ -640,8 +659,9 @@ const groupResolvers = {
 
         logger.info({ req_id, user, org_id, uuid, clusters }, `${queryName} returning`);
         return {modified: res.modifiedCount };
-      } catch (error) {
-        logger.error({ req_id, user, org_id, uuid, clusters, error }, `${queryName} error encountered: ${error.message}`);
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }

--- a/app/apollo/resolvers/organization.js
+++ b/app/apollo/resolvers/organization.js
@@ -68,7 +68,7 @@ const organizationResolvers = {
         return foundOrgKey;
       }
       catch( error ) {
-        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        logger.error({ req_id, user, org_id: orgId, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }
@@ -159,7 +159,7 @@ const organizationResolvers = {
       }
       catch( error ) {
         // Note: if using an external auth plugin, it's organization schema must define the OrgKeys2 attribute else query will throw an error.
-        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        logger.error({ req_id, user, org_id: orgId, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }
@@ -258,7 +258,7 @@ const organizationResolvers = {
       }
       catch( error ) {
         // Note: if using an external auth plugin, it's organization schema must define the OrgKeys2 attribute else query will throw an error.
-        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        logger.error({ req_id, user, org_id: orgId, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }
@@ -394,7 +394,7 @@ const organizationResolvers = {
       }
       catch( error ) {
         // Note: if using an external auth plugin, it's organization schema must define the OrgKeys2 attribute else query will throw an error.
-        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        logger.error({ req_id, user, org_id: orgId, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }
@@ -511,7 +511,7 @@ const organizationResolvers = {
       }
       catch( error ) {
         // Note: if using an external auth plugin, it's organization schema must define the OrgKeys2 attribute else query will throw an error.
-        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        logger.error({ req_id, user, org_id: orgId, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }

--- a/app/apollo/resolvers/organization.js
+++ b/app/apollo/resolvers/organization.js
@@ -53,18 +53,27 @@ const organizationResolvers = {
 
       logger.info({ req_id, user, orgId, uuid }, `${queryName} enter`);
 
-      const allOrgKeys = await organizationResolvers.Query.orgKeys( parent, { orgId }, context );
+      try {
+        const allOrgKeys = await organizationResolvers.Query.orgKeys( parent, { orgId }, context );
 
-      const foundOrgKey = allOrgKeys.find( e => {
-        return( e.uuid === uuid || e.name === name );
-      } );
+        const foundOrgKey = allOrgKeys.find( e => {
+          return( e.uuid === uuid || e.name === name );
+        } );
 
-      if( !foundOrgKey ){
-        logger.info({ req_id, user, orgId }, `${queryName} OrgKey not found: ${uuid}/${name}`);
-        throw new NotFoundError( context.req.t( 'Could not find the organization key.' ), context );
+        if( !foundOrgKey ){
+          logger.info({ req_id, user, orgId }, `${queryName} OrgKey not found: ${uuid}/${name}`);
+          throw new NotFoundError( context.req.t( 'Could not find the organization key.' ), context );
+        }
+
+        return foundOrgKey;
       }
-
-      return foundOrgKey;
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        if (error instanceof BasicRazeeError || error instanceof ValidationError) {
+          throw error;
+        }
+        throw new RazeeQueryError(context.req.t('Query {{queryName}} error. MessageID: {{req_id}}.', {'queryName':queryName, 'req_id':req_id}), context);
+      }
     },
 
     orgKeys: async (parent, { orgId }, context) => {
@@ -75,38 +84,38 @@ const organizationResolvers = {
 
       logger.info({ req_id, user, orgId }, `${queryName} enter`);
 
-      await validAuth(me, orgId, ACTIONS.READ, TYPES.ORGANIZATION, queryName, context);
-      logger.info({ req_id, user, orgId }, `${queryName} user has ORGANIZATION READ`);
-
-      let userCanViewKeyValues = false;
       try {
         await validAuth(me, orgId, ACTIONS.READ, TYPES.ORGANIZATION, queryName, context);
-        logger.info({ req_id, user, orgId }, `${queryName} user has MANAGE`);
-        userCanViewKeyValues = true;
-      }
-      catch( e ) {
-        logger.info({ req_id, user, orgId }, `${queryName} user does not have MANAGE`);
-      }
+        logger.info({ req_id, user, orgId }, `${queryName} user has ORGANIZATION READ`);
 
-      try {
-        await validAuth(me, orgId, ACTIONS.ATTACH, TYPES.CLUSTER, queryName, context);
-        logger.info({ req_id, user, orgId }, `${queryName} user has CLUSTER ATTACH`);
-        userCanViewKeyValues = true;
-      }
-      catch( e ) {
-        logger.info({ req_id, user, orgId }, `${queryName} user does not have CLUSTER ATTACH`);
-      }
+        let userCanViewKeyValues = false;
+        try {
+          await validAuth(me, orgId, ACTIONS.READ, TYPES.ORGANIZATION, queryName, context);
+          logger.info({ req_id, user, orgId }, `${queryName} user has MANAGE`);
+          userCanViewKeyValues = true;
+        }
+        catch( e ) {
+          logger.info({ req_id, user, orgId }, `${queryName} user does not have MANAGE`);
+        }
 
-      try {
-        await validAuth(me, orgId, ACTIONS.REGISTER, TYPES.CLUSTER, queryName, context);
-        logger.info({ req_id, user, orgId }, `${queryName} user has CLUSTER REGISTER`);
-        userCanViewKeyValues = true;
-      }
-      catch( e ) {
-        logger.info({ req_id, user, orgId }, `${queryName} user does not have CLUSTER REGISTER`);
-      }
+        try {
+          await validAuth(me, orgId, ACTIONS.ATTACH, TYPES.CLUSTER, queryName, context);
+          logger.info({ req_id, user, orgId }, `${queryName} user has CLUSTER ATTACH`);
+          userCanViewKeyValues = true;
+        }
+        catch( e ) {
+          logger.info({ req_id, user, orgId }, `${queryName} user does not have CLUSTER ATTACH`);
+        }
 
-      try {
+        try {
+          await validAuth(me, orgId, ACTIONS.REGISTER, TYPES.CLUSTER, queryName, context);
+          logger.info({ req_id, user, orgId }, `${queryName} user has CLUSTER REGISTER`);
+          userCanViewKeyValues = true;
+        }
+        catch( e ) {
+          logger.info({ req_id, user, orgId }, `${queryName} user does not have CLUSTER REGISTER`);
+        }
+
         const org = await models.Organization.findById(orgId);
         logger.info({ req_id, user, orgId }, `${queryName} org retrieved`);
         //console.log( `org: ${JSON.stringify(org, null, 2)}` );
@@ -147,15 +156,14 @@ const organizationResolvers = {
 
         // Return the orgKeys
         return allOrgKeys;
-      } catch (error) {
+      }
+      catch( error ) {
         // Note: if using an external auth plugin, it's organization schema must define the OrgKeys2 attribute else query will throw an error.
-
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }
-
-        logger.error({ req_id, user, orgId, error }, `${queryName} error encountered`);
-        throw new RazeeQueryError(context.req.t('Query {{queryName}} error. {{error.message}}', {'queryName':queryName, 'error.message':error.message}), context);
+        throw new RazeeQueryError(context.req.t('Query {{queryName}} error. MessageID: {{req_id}}.', {'queryName':queryName, 'req_id':req_id}), context);
       }
     },
   },
@@ -247,9 +255,10 @@ const organizationResolvers = {
         // Return the new orgKey uuid and key value
         logger.info({ req_id, user, orgId, name, primary }, `${queryName} returning`);
         return { uuid: newOrgKey.orgKeyUuid, key: newOrgKey.key };
-      } catch (error) {
+      }
+      catch( error ) {
         // Note: if using an external auth plugin, it's organization schema must define the OrgKeys2 attribute else query will throw an error.
-        logger.error({ req_id, user, orgId, name, primary, error }, `${queryName} error encountered: ${error.message}`);
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }
@@ -382,9 +391,10 @@ const organizationResolvers = {
 
         logger.info({ req_id, user, orgId, uuid, forceDeletion }, `${queryName} returning`);
         return { success: true };
-      } catch (error) {
+      }
+      catch( error ) {
         // Note: if using an external auth plugin, it's organization schema must define the OrgKeys2 attribute else query will throw an error.
-        logger.error({ req_id, user, orgId, uuid, forceDeletion, error }, `${queryName} error encountered: ${error.message}`);
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }
@@ -498,9 +508,10 @@ const organizationResolvers = {
         return {
           modified: res.modifiedCount
         };
-      } catch (error) {
+      }
+      catch( error ) {
         // Note: if using an external auth plugin, it's organization schema must define the OrgKeys2 attribute else query will throw an error.
-        logger.error({ req_id, user, orgId, uuid, name, primary, error }, `${queryName} error encountered: ${error.message}`);
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }

--- a/app/apollo/resolvers/serviceSubscription.js
+++ b/app/apollo/resolvers/serviceSubscription.js
@@ -66,7 +66,7 @@ const serviceResolvers = {
         throw new NotFoundError(context.req.t('Subscription { id: "{{id}}" } not found.', { 'id': id }), context);
       }
       catch( error ) {
-        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        logger.error({ req_id, user, org_id: orgId, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }
@@ -107,7 +107,7 @@ const serviceResolvers = {
         return serviceSubscriptions;
       }
       catch( error ) {
-        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        logger.error({ req_id, user, org_id: orgId, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }
@@ -135,7 +135,7 @@ const serviceResolvers = {
         return serviceSubscription;
       }
       catch( error ) {
-        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        logger.error({ req_id, user, org_id: orgId, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }

--- a/app/apollo/resolvers/serviceSubscription.js
+++ b/app/apollo/resolvers/serviceSubscription.js
@@ -50,19 +50,28 @@ const serviceResolvers = {
 
       logger.debug({ req_id, user, orgId }, `${queryName} enter`);
 
-      await validAuth(me, orgId, ACTIONS.READ, TYPES.SERVICESUBSCRIPTION, queryName, context);
+      try {
+        await validAuth(me, orgId, ACTIONS.READ, TYPES.SERVICESUBSCRIPTION, queryName, context);
 
-      let subscription = await models.ServiceSubscription.findOne({ _id: id, org_id: orgId }).lean(); // search only in the user org
-      if (subscription) {
-        return 'SERVICE';
+        let subscription = await models.ServiceSubscription.findOne({ _id: id, org_id: orgId }).lean(); // search only in the user org
+        if (subscription) {
+          return 'SERVICE';
+        }
+
+        subscription = await models.Subscription.findOne({ uuid: id, org_id: orgId }, {}).lean(); // search only in the user org
+        if (subscription) {
+          return 'USER';
+        }
+
+        throw new NotFoundError(context.req.t('Subscription { id: "{{id}}" } not found.', { 'id': id }), context);
       }
-
-      subscription = await models.Subscription.findOne({ uuid: id, org_id: orgId }, {}).lean(); // search only in the user org
-      if (subscription) {
-        return 'USER';
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        if (error instanceof BasicRazeeError || error instanceof ValidationError) {
+          throw error;
+        }
+        throw new RazeeQueryError(context.req.t('Query {{queryName}} error. MessageID: {{req_id}}.', {'queryName':queryName, 'req_id':req_id}), context);
       }
-
-      throw new NotFoundError(context.req.t('Subscription { id: "{{id}}" } not found.', { 'id': id }), context);
     },
 
     serviceSubscriptions: async(parent, { orgId }, context, fullQuery) => {
@@ -74,27 +83,36 @@ const serviceResolvers = {
 
       logger.debug({req_id, user, orgId }, `${queryName} enter`);
 
-      await validAuth(me, orgId, ACTIONS.READ, TYPES.SERVICESUBSCRIPTION, queryName, context);
+      try {
+        await validAuth(me, orgId, ACTIONS.READ, TYPES.SERVICESUBSCRIPTION, queryName, context);
 
-      let serviceSubscriptions = [];
-      try{
-        checkComplexity( queryFields );
+        let serviceSubscriptions = [];
+        try{
+          checkComplexity( queryFields );
 
-        // User is allowed to see a service subscription only if they have subscription READ permission in the target cluster org
-        for await (const ss of models.ServiceSubscription.find({org_id: orgId}).lean({ virtuals: true })) {
-          const allowed = await filterSubscriptionsToAllowed(me, ss.clusterOrgId, ACTIONS.READ, TYPES.SERVICESUBSCRIPTION, [ss], context);
-          serviceSubscriptions = serviceSubscriptions.concat(allowed);
+          // User is allowed to see a service subscription only if they have subscription READ permission in the target cluster org
+          for await (const ss of models.ServiceSubscription.find({org_id: orgId}).lean({ virtuals: true })) {
+            const allowed = await filterSubscriptionsToAllowed(me, ss.clusterOrgId, ACTIONS.READ, TYPES.SERVICESUBSCRIPTION, [ss], context);
+            serviceSubscriptions = serviceSubscriptions.concat(allowed);
+          }
+        }catch(error){
+          logger.error(error);
+          throw new NotFoundError(context.req.t('Failed to retrieve service subscriptions.'), context);
         }
-      }catch(error){
-        logger.error(error);
-        throw new NotFoundError(context.req.t('Failed to retrieve service subscriptions.'), context);
+
+        serviceSubscriptions.forEach(i => i.ssid = i.uuid);
+
+        await applyQueryFieldsToSubscriptions(serviceSubscriptions, queryFields, { orgId, servSub: true }, context);
+
+        return serviceSubscriptions;
       }
-
-      serviceSubscriptions.forEach(i => i.ssid = i.uuid);
-
-      await applyQueryFieldsToSubscriptions(serviceSubscriptions, queryFields, { orgId, servSub: true }, context);
-
-      return serviceSubscriptions;
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        if (error instanceof BasicRazeeError || error instanceof ValidationError) {
+          throw error;
+        }
+        throw new RazeeQueryError(context.req.t('Query {{queryName}} error. MessageID: {{req_id}}.', {'queryName':queryName, 'req_id':req_id}), context);
+      }
     },
 
     serviceSubscription: async (parent, { orgId, ssid }, context, fullQuery) => {
@@ -105,15 +123,24 @@ const serviceResolvers = {
 
       logger.debug({ req_id, user, orgId, ssid }, `${queryName} enter`);
 
-      const allServiceSubscriptions = await serviceResolvers.Query.serviceSubscriptions(parent, { orgId }, { models, me, req_id, logger }, fullQuery);
+      try {
+        const allServiceSubscriptions = await serviceResolvers.Query.serviceSubscriptions(parent, { orgId }, { models, me, req_id, logger }, fullQuery);
 
-      const serviceSubscription = allServiceSubscriptions.find((sub) => {
-        return (sub.ssid == ssid);
-      });
-      if (!serviceSubscription) { // does not exist or user does not have right to see it
-        throw new NotFoundError(context.req.t('Service subscription with ssid "{{ssid}}" not found.', { 'ssid': ssid }), context);
+        const serviceSubscription = allServiceSubscriptions.find((sub) => {
+          return (sub.ssid == ssid);
+        });
+        if (!serviceSubscription) { // does not exist or user does not have right to see it
+          throw new NotFoundError(context.req.t('Service subscription with ssid "{{ssid}}" not found.', { 'ssid': ssid }), context);
+        }
+        return serviceSubscription;
       }
-      return serviceSubscription;
+      catch( error ) {
+        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        if (error instanceof BasicRazeeError || error instanceof ValidationError) {
+          throw error;
+        }
+        throw new RazeeQueryError(context.req.t('Query {{queryName}} error. MessageID: {{req_id}}.', {'queryName':queryName, 'req_id':req_id}), context);
+      }
     },
 
     allSubscriptions: async (parent, { orgId }, context, fullQuery) => {
@@ -193,8 +220,9 @@ const serviceResolvers = {
 
         logger.info( {req_id, user, orgId, name, clusterId, channelUuid, versionUuid }, `${queryName} returning` );
         return ssid;
-      } catch (error) {
-        logger.error({ req_id, user, orgId, name, clusterId, channelUuid, versionUuid, error }, `${queryName} error encountered: ${error.message}`);
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id: orgId, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }
@@ -245,8 +273,9 @@ const serviceResolvers = {
 
         logger.info( { req_id, user, orgId, ssid }, `${queryName} returning` );
         return ssid;
-      } catch (error) {
-        logger.error({ req_id, user, orgId, ssid, error }, `${queryName} error encountered: ${error.message}`);
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id: orgId, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }
@@ -282,8 +311,9 @@ const serviceResolvers = {
 
         logger.info( {req_id, user, orgId, ssid}, `${queryName} returning` );
         return ssid;
-      } catch (error) {
-        logger.error({ req_id, user, orgId, ssid, error }, `${queryName} error encountered: ${error.message}`);
+      }
+      catch( error ) {
+        logger.error({ req_id, user, org_id: orgId, error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }

--- a/app/apollo/resolvers/subscription.js
+++ b/app/apollo/resolvers/subscription.js
@@ -119,7 +119,7 @@ const subscriptionResolvers = {
         return subs;
       }
       catch( error ) {
-        logger.error({ req_id, user, org_id, error }, `${queryName} error encountered: ${error.message}`);
+        logger.error({ req_id, user, /*org_id,*/ error }, `${queryName} error encountered: ${error.message}`);
         if (error instanceof BasicRazeeError || error instanceof ValidationError) {
           throw error;
         }


### PR DESCRIPTION
Ensures common errors such as "NotFound" are reported as such consistently, while unexpected/internal errors are consistently wrapped as generic "Query {{queryName}} error. MessageID: {{req_id}}." to avoid exposing internal details.