### PR TITLE
allow subscription groups to be specified by name or uuid

### DIFF
--- a/app/apollo/test/subscriptions.spec.js
+++ b/app/apollo/test/subscriptions.spec.js
@@ -731,11 +731,11 @@ describe('subscription graphql test suite', () => {
       });
       expect(addSubscription2.data.errors[0].message).to.equal(`Too many subscriptions are registered under ${org01._id}.`);  // limit is set in definition of test job in package.json
 
-      // add subscription with custom attribute
+      // add subscription with custom attribute, using group uuid
       const result = await subscriptionApi.addSubscription(token77, {
         orgId: org77._id,
         name: 'a_random_name3',
-        groups:['dev'],
+        groups:[org77_group_dev_uuid],
         channelUuid: channel_04_uuid,
         versionUuid: channelVersion_04_uuid,
         custom: {
@@ -761,7 +761,7 @@ describe('subscription graphql test suite', () => {
         orgId: org01._id,
         uuid: subscription_01_uuid,
         name: 'new-name',
-        groups:['new-tag'],
+        groups:['dev'],
         channelUuid: channel_02_uuid,
         versionUuid: channelVersion_03_uuid,
       });
@@ -791,7 +791,7 @@ describe('subscription graphql test suite', () => {
         orgId: org77._id,
         uuid: subscription_04_uuid,
         name: 'new-name',
-        groups:['new-tag'],
+        groups:['dev'],
         channelUuid: channel_04_uuid,
         versionUuid: channelVersion_04_uuid,
         custom: {

--- a/app/apollo/utils/subscriptionUtils.js
+++ b/app/apollo/utils/subscriptionUtils.js
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-const { whoIs, RazeeValidationError } = require ('../resolvers/common');
+const { RazeeValidationError } = require ('../resolvers/common');
 const { SUBSCRIPTION_LIMITS } = require('../models/const');
 const { validateString } = require('./directives');
 
+// Validate that specified groups (by name or uuid) exist, return array of group names
 const getGroupNames = async ( org_id, groupNamesOrUuids, context ) => {
-  const { req_id, me, models, logger } = context;
+  const { models } = context;
   // Get all groups
   const allGroups = await models.Group.find({ org_id: org_id });
 

--- a/app/apollo/utils/subscriptionUtils.js
+++ b/app/apollo/utils/subscriptionUtils.js
@@ -18,21 +18,28 @@ const { whoIs, RazeeValidationError } = require ('../resolvers/common');
 const { SUBSCRIPTION_LIMITS } = require('../models/const');
 const { validateString } = require('./directives');
 
-const validateGroups = async ( org_id, groups, context ) => {
+const getGroupNames = async ( org_id, groupNamesOrUuids, context ) => {
   const { req_id, me, models, logger } = context;
-  // validate cluster groups exists in the groups db
-  let groupCount = await models.Group.count({org_id: org_id, name: {$in: groups} });
-  if (groupCount < groups.length) {
-    if (process.env.LABEL_VALIDATION_REQUIRED) {
-      throw new RazeeValidationError(context.req.t('Could not find all the cluster groups {{groups}} in the groups database, please create them first.', {'groups':groups}), context);
-    } else {
-      // in migration period, we automatically populate groups into label db
-      logger.info({req_id, user: whoIs(me), org_id}, `could not find all the cluster groups ${groups}, migrate them into label database.`);
-      await models.Group.findOrCreateList(models, org_id, groups, context);
-      groupCount = await models.Group.count({org_id: org_id, name: {$in: groups} });
+  // Get all groups
+  const allGroups = await models.Group.find({ org_id: org_id });
+
+  const groupNames = [];
+
+  for( const groupNameOrUuid of groupNamesOrUuids ) {
+    const matchingGroup = allGroups.find( g => {
+      return( g.name == groupNameOrUuid || g.uuid == groupNameOrUuid );
+    } );
+
+    if( matchingGroup ) {
+      groupNames.push( matchingGroup.name );
+    }
+    else {
+      throw new RazeeValidationError(context.req.t('Could not find all the cluster groups {{groups}} in the groups database, please create them first.', {'groups':groupNamesOrUuids}), context);
     }
   }
-};
+
+  return( groupNames );
+}
 
 // validate the number of total subscriptions are under the limit
 const validateSubscriptionLimit = async ( org_id, newCount, context ) => {
@@ -56,7 +63,7 @@ const validateNewSubscriptions = async ( org_id, { versions, newSubscriptions },
     s.groups.forEach( value => { validateString( 'groups', value ); } );
 
     // validate groups all exist
-    await validateGroups(org_id, s.groups, context);
+    await getGroupNames(org_id, s.groups, context);
 
     // validate the subscription references the version(s)
     const badVersionRef = versions.find( v => v.name === s.versionName ).length == 0;
@@ -68,7 +75,7 @@ const validateNewSubscriptions = async ( org_id, { versions, newSubscriptions },
 
 
 module.exports = {
-  validateGroups,
+  getGroupNames,
   validateSubscriptionLimit,
   validateNewSubscriptions,
 };

--- a/app/apollo/utils/subscriptionUtils.js
+++ b/app/apollo/utils/subscriptionUtils.js
@@ -40,7 +40,7 @@ const getGroupNames = async ( org_id, groupNamesOrUuids, context ) => {
   }
 
   return( groupNames );
-}
+};
 
 // validate the number of total subscriptions are under the limit
 const validateSubscriptionLimit = async ( org_id, newCount, context ) => {


### PR DESCRIPTION
- allow subscription groups to be specified by name or uuid
- do not automatically create groups that do not exist