### PR TITLE
fixed error logging when deployableVersionObj is not found in gql.cha…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ dev/
 
 # MEND unified agent
 wss-unified-agent.jar
+
+.idea/

--- a/app/apollo/resolvers/channel.js
+++ b/app/apollo/resolvers/channel.js
@@ -235,7 +235,7 @@ const channelResolvers = {
 
         // If no matching version found, throw an error
         if (!deployableVersionObj) {
-          throw new NotFoundError(context.req.t('DeployableVersion is not found for {{channel.name}}:{{channel.uuid}}/{{versionObj.name}}:{{versionObj.uuid}}.', {'channel.name':channel.name, 'channel.uuid':channel.uuid, 'versionName':versionName, 'versionObj.uuid':versionUuid}), context);
+          throw new NotFoundError(context.req.t('DeployableVersion is not found for {{channelName}}:{{channelUuid}}/{{versionName}}:{{versionUuid}}.', {'channelName':channel.name, 'channelUuid':channel.uuid, 'versionName':versionName, 'versionUuid':versionUuid}), context);
         }
 
         await applyQueryFieldsToDeployableVersions([ deployableVersionObj ], queryFields, { orgId: org_id }, context);


### PR DESCRIPTION
fixed error logging when deployableVersionObj is not found in gql.channels.channelVersion()

The problems seems to have come up when we added translation. I suspect the translation layer doesnt like the nested variable names.